### PR TITLE
fix: gcloud requirement check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Check gcloud is required
         id: check-gcloud
         run: |
-          if [[ $HAS_GCP_SA_KEY_JSON == "true" ]]; then
-            if [[ "$(cat package.json)" != *\"gcloud\"* ]] && [[ "$(cat packages/*/package.json 2> /dev/null)" != *\"gcloud\"* ]]; then
+          if [[ $HAS_GCP_SA_KEY_JSON == "true"  ]]; then
+            if [[ "$(cat package.json)" == *gcloud* || "$(cat packages/*/package.json)" == *gcloud* ]]; then
               echo "require-gcloud=1" >> $GITHUB_OUTPUT
             fi
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,10 @@ jobs:
       - name: Check gcloud is required
         id: check-gcloud
         run: |
-          if [[ $HAS_GCP_SA_KEY_JSON == "true" && "$(cat package.json packages/*/package.json)" != *"gcloud"* ]]; then
-            echo "require-gcloud=1" >> $GITHUB_OUTPUT
+          if [[ $HAS_GCP_SA_KEY_JSON == "true" ]]; then
+            if [[ "$(cat package.json)" != *\"gcloud\"* ]] && [[ "$(cat packages/*/package.json 2> /dev/null)" != *\"gcloud\"* ]]; then
+              echo "require-gcloud=1" >> $GITHUB_OUTPUT
+            fi
           fi
       - if: ${{ steps.check-ver.outputs.exist-version-files || steps.check-gcloud.outputs.require-gcloud }}
         uses: willbooster/asdf-actions/install@main


### PR DESCRIPTION
`gcloud`の必要性チェックが上手く動いていない影響で、[OJのdeploy](https://github.com/WillBoosterLab/online-judge/actions/runs/3612698073/jobs/6087981227)にて`gcloud`のインストールが上手くいっておらずエラーになっていたので、その修正です。
- `packages/*/package.json` が存在しない場合、[`cat: packages/*/package.json: No such file or directory` となってしまっていた](https://github.com/WillBoosterLab/online-judge/actions/runs/3612698073/jobs/6087981227#step:5:17)ので、ファイルが存在しなくてもエラーにならないようにしました。
- `package.json`の文字列の一致判定では、おそらく`gcloud`ではなく`"gcloud"`を使うべきだと思われるので、`"gcloud"`で判定するようにしました。
  - `gcloud`だと[`"deploy/clean": "gcloud artifacts docker images list ...`](https://github.com/WillBoosterLab/online-judge/blob/1ba88e6b51e43701d2782fbb5403da7ba0fbf486/package.json#L21)のような文字列にも一致してしまいます。if文の意図としては、「`package.json`ですでに`gcloud`のバージョン指定をしている場合は`require-gcloud=1"`にしない」ということだと思われるので、バージョン指定のみに一致する`"gcloud"`としました。