### PR TITLE
fix: upgrade Node.js for Sync workflow and Willboosterify workflow from 18 to 20

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,7 +30,7 @@ jobs:
       # We prefer actions/setup-node to asdf because asdf is slow on GitHub runners
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Show environment information
         run: |
           echo "node: $(node -v)"

--- a/.github/workflows/wbfy.yml
+++ b/.github/workflows/wbfy.yml
@@ -41,7 +41,7 @@ jobs:
       # We prefer actions/setup-node to asdf because asdf is slow on GitHub runners
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212


### PR DESCRIPTION
最新のNext.jsを使用したプロジェクトで、Willboosterifyワークフローが、Node.jsのバージョンが古いことに起因するエラーを発生させていた。

```
Process started
Read 9 environment variables: .env.development
Run 'yarn run build/core'
You are using Node.js 18.12.1. For Next.js, Node.js version >= v18.17.0 is required.
Process exited (exit code 1), completed in 2s 938ms
```
