### PR TITLE
fix(test): set `test` as the default value of `WB_ENV`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       # arguments
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_TEST_COMMAND: ${{ !!inputs.custom_test_command }}
-      WB_ENV: ${{ inputs.environment }}
+      WB_ENV: ${{ inputs.environment || 'test' }}
     strategy:
       matrix:
         # c.f. https://github.community/t/reusable-workflow-with-strategy-matrix/205676


### PR DESCRIPTION
`test`ワークフローにおいて、現状では`inputs.environment`が空の場合、`WB_ENV`も空になる。すると、`test`ワークフローの中でもコマンドによって異なるenvファイルが読み込まれるようになる。例えば`wb prisma reset`では`.env.development`が読み込まれるが`wb test --ci`では`.env.test`が読み込まれる。
