### PR TITLE
fix: install lts node in setup-node fallbacks

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           check-latest: true
+          node-version: lts/*
       - if: ${{ steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           check-latest: true
+          node-version: lts/*
       - if: ${{ steps.check-ver.outputs.exist-any-version || steps.check-gcloud.outputs.require-gcloud }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           check-latest: true
+          node-version: lts/*
       - if: ${{ steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           check-latest: true
+          node-version: lts/*
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         id: detect-node-version-matrix
         # We must use actions/setup-node if no Node.js description exists in mise-managed files and no .node-version exists.
@@ -156,7 +157,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           check-latest: true
-          node-version: ${{ matrix.node-version || 22 }}
+          node-version: ${{ matrix.node-version || 'lts/*' }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:


### PR DESCRIPTION
## Summary

- Configure setup-node fallback steps to install latest LTS with `node-version: lts/*` instead of keeping the runner PATH Node.
- Update the reusable test workflow fallback matrix from Node 22 to latest LTS.

## Testing

- `yarn check-for-ai`
