### PR TITLE
chore: update one-way-git-sync to 6.0.41

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -20,6 +20,7 @@ npmPreapprovedPackages:
   - '@willbooster/prettier-config'
   - '@willbooster/shared-lib'
   - '@willbooster/wb'
+  - one-way-git-sync
   - next
   - '@next/*'
   - react

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@willbooster/prettier-config": "10.4.0",
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
-    "one-way-git-sync": "6.0.40",
+    "one-way-git-sync": "6.0.41",
     "pinst": "3.0.0",
     "prettier": "3.8.1",
     "prettier-plugin-java": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@simple-git/args-pathspec@npm:1.0.2"
+  checksum: 10c0/e74a827baa9ee3e5ad8d10205a3d8a74d4251e5dbf12b0f7d485e687c903042c7c74beec71336226f8dd310c7292a73ebc911b345cfa3116cf75c230f26f3074
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/argv-parser@npm:1.0.3"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.2"
+  checksum: 10c0/687936b8e35a2f2e569ce7cef9a2c2b9be174d0da1c0e8de21f6bedb444dda34b3103741378c3356cc343a8b439a2342c38956c131579e94e2acf703064ee31f
+  languageName: node
+  linkType: hard
+
 "@willbooster/prettier-config@npm:10.4.0":
   version: 10.4.0
   resolution: "@willbooster/prettier-config@npm:10.4.0"
@@ -513,19 +529,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"one-way-git-sync@npm:6.0.40":
-  version: 6.0.40
-  resolution: "one-way-git-sync@npm:6.0.40"
+"one-way-git-sync@npm:6.0.41":
+  version: 6.0.41
+  resolution: "one-way-git-sync@npm:6.0.41"
   dependencies:
     fs-extra: "npm:11.3.4"
     micromatch: "npm:4.0.8"
     pino: "npm:10.3.1"
     pino-pretty: "npm:13.1.3"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.35.2"
     yargs: "npm:18.0.0"
   bin:
     one-way-git-sync: bin/index.js
-  checksum: 10c0/265946bb075851747e4b6da495d21ab45f998717c62e9f153d8ad4d5cb158bf43ec0767288449d9e360908b8fcbeec81798524ecea4303d5411365401298c699
+  checksum: 10c0/e14a56bff54b4e469d8659e317cd370790b40432030cda15a599326ae9b0cf274ab58dfd17e9363d6e153490cdb0e392f55b3e375fe6cc6a85272471cdc32ab5
   languageName: node
   linkType: hard
 
@@ -689,7 +705,7 @@ __metadata:
     "@willbooster/prettier-config": "npm:10.4.0"
     husky: "npm:9.1.7"
     lint-staged: "npm:16.4.0"
-    one-way-git-sync: "npm:6.0.40"
+    one-way-git-sync: "npm:6.0.41"
     pinst: "npm:3.0.0"
     prettier: "npm:3.8.1"
     prettier-plugin-java: "npm:2.8.1"
@@ -734,14 +750,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:3.33.0":
-  version: 3.33.0
-  resolution: "simple-git@npm:3.33.0"
+"simple-git@npm:3.35.2":
+  version: 3.35.2
+  resolution: "simple-git@npm:3.35.2"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
+    "@simple-git/args-pathspec": "npm:^1.0.2"
+    "@simple-git/argv-parser": "npm:^1.0.3"
     debug: "npm:^4.4.0"
-  checksum: 10c0/463e91f3ee04b7fc445284c64502a4ee3d607f626f18c8bcc036815a30fe178d2216976e683c6368edd7b3093801d6e534deeb8e700a4863a76ef23f881a0712
+  checksum: 10c0/9cc675d4591713dc90856526f9a671ce614d2e75079988628df6eb6ce3e7ec629ae6ec77736c76960a85a9a1a6a9ee218c03eda016acb0c21bf6829f55422cb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Update `one-way-git-sync` from `6.0.40` to `6.0.41`.
- Preapprove `one-way-git-sync` in Yarn's npm age gate so the freshly published internal sync package can be installed immediately.
- Refresh `yarn.lock` for the updated transitive `simple-git` dependency set.

## Why

- `yarn sync-force` previously failed because the destination sync commit referenced a source hash no longer reachable in this repository.
- `one-way-git-sync@6.0.41` contains the force-sync fallback for stale source hashes.

## Testing

- `yarn up one-way-git-sync@6.0.41`
- `yarn sync-force`
- `yarn check-for-ai`
