### PR TITLE
fix: retry transient pkg-preflight failures

### DIFF
--- a/.github/scripts/create-pkg-preflight-request.cjs
+++ b/.github/scripts/create-pkg-preflight-request.cjs
@@ -191,10 +191,9 @@ function postRequest(requestPath) {
     [
       '--fail-with-body',
       '--max-time',
-      '60',
+      '120',
       '--retry',
       String(PkgPreflightRetryAttempts),
-      '--retry-all-errors',
       '--retry-delay',
       String(PkgPreflightRetryDelaySeconds),
       '--show-error',

--- a/.github/scripts/create-pkg-preflight-request.cjs
+++ b/.github/scripts/create-pkg-preflight-request.cjs
@@ -5,6 +5,8 @@ const path = require('node:path');
 
 const MaxFilesPerRequest = 100;
 const PkgPreflightUrl = 'https://pkg-preflight.up.railway.app';
+const PkgPreflightRetryAttempts = 5;
+const PkgPreflightRetryDelaySeconds = 10;
 const KnownLockfileNames = new Set([
   'constraints.txt',
   'go.sum',
@@ -190,6 +192,11 @@ function postRequest(requestPath) {
       '--fail-with-body',
       '--max-time',
       '60',
+      '--retry',
+      String(PkgPreflightRetryAttempts),
+      '--retry-all-errors',
+      '--retry-delay',
+      String(PkgPreflightRetryDelaySeconds),
       '--show-error',
       '--silent',
       `${PkgPreflightUrl}/rpc/inspectLockfileDiff`,


### PR DESCRIPTION
## Summary

- pkg-preflight API への curl POST に retry を追加しました
- 503 など一時的な外部サービス失敗で reusable workflow が即 fail しないようにしました

## Why

- pkg-preflight は CI の外部依存であり、デプロイ中の maintenance page など一時的な 503 が発生し得ます
- lockfile preflight の判定自体ではなくサービス到達性の問題で PR CI が落ちるのを避けるためです

## Testing

- `node --check .github/scripts/create-pkg-preflight-request.cjs`
- `yarn check-for-ai`
