### PR TITLE
fix: update semantic pull request action

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       FORCE_COLOR: 3
     steps:
-      - uses: amannn/action-semantic-pull-request@ac7e3fc035c47465748bbcb1a822c1583cf79bbc
+      - uses: amannn/action-semantic-pull-request@45b9ed7cf24087a2f7785bf55be97394ba87e1c2
         with:
           wip: true
         env:


### PR DESCRIPTION
## Summary
- Update `amannn/action-semantic-pull-request` to the latest inspected upstream default-branch commit.

## Inspection notes
- `fkirc/skip-duplicate-actions` is already pinned to its upstream default-branch head (`04a1aebe...`); the latest release tag is older.
- `autofix-ci/action` is not referenced by this repository's reusable workflows. Its latest `v1.3.4` tag resolves to the same commit as the current `v1` tag used by generated public workflows elsewhere.
- `skip-duplicate-actions` still documents `actions: write` as a minimum permission when repository token defaults are read-only.

## Verification
- `yarn check-for-ai`
