### PR TITLE
ci: isolate GPG home for mise on self-hosted runners

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           check-latest: true
           node-version: lts/*
+      - if: ${{ steps.check-ver.outputs.exist-any-version && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
       - if: ${{ steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,12 @@ jobs:
         with:
           check-latest: true
           node-version: lts/*
+      - if: ${{ (steps.check-ver.outputs.exist-any-version || steps.check-gcloud.outputs.require-gcloud) && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
       - if: ${{ steps.check-ver.outputs.exist-any-version || steps.check-gcloud.outputs.require-gcloud }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -98,6 +98,12 @@ jobs:
         with:
           check-latest: true
           node-version: lts/*
+      - if: ${{ steps.check-ver.outputs.exist-any-version && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
       - if: ${{ steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
         with:
           node-version: '24.16.0'
           check-latest: true
+      - if: ${{ steps.check-ver.outputs.exist-any-version && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
       - if: ${{ steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,12 @@ jobs:
         with:
           check-latest: true
           node-version: ${{ matrix.node-version || 'lts/*' }}
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.check-ver.outputs.exist-any-version && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
       - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.check-ver.outputs.exist-any-version }}
         uses: jdx/mise-action@v4
         with:


### PR DESCRIPTION
## Summary

- Add a self-hosted-only step before `jdx/mise-action` to create an isolated `GNUPGHOME` with `mktemp -d`.
- Apply the fix to workflows that run mise: autofix, deploy, gen-pr, release, and test.

## Why

Self-hosted runners can run multiple jobs against the same user-level GnuPG home. When mise installs Node and imports/verifies GPG keys concurrently, shared keybox locks can fail with `database_open ... waiting for lock` and `gpg failed` errors.

Using a job-local GPG home under `$RUNNER_TEMP` avoids sharing `~/.gnupg` while keeping GPG state consistent within the job.

## Testing

- `yarn check-for-ai`
