### PR TITLE
fix: run semantic-release dry-run with package runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,9 +304,9 @@ jobs:
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.GITHUB_TOKEN != '' && github.event_name == 'pull_request' }}
         name: Test release script
         run: |
-          if [[ "$(jq -r '.dependencies["semantic-release"] != null or .devDependencies["semantic-release"] != null' package.json)" == "true" ]]; then
+          if grep -q '"semantic-release":' package.json; then
             git switch -C "$(jq -r ".branches[0]" .releaserc.json)"
-            if [[ "$(jq -r '.scripts["release-test"] != null' package.json)" == "true" ]]; then
+            if grep -q '"release-test":' package.json; then
               ${{ steps.env-info.outputs.runner }} run release-test
             else
               ${{ steps.env-info.outputs.runner }} semantic-release --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,13 +304,9 @@ jobs:
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.GITHUB_TOKEN != '' && github.event_name == 'pull_request' }}
         name: Test release script
         run: |
-          if grep -q '"semantic-release":' package.json; then
-            git switch -C $(jq -r ".branches[0]" .releaserc.json)
-            if grep -q '"release-test":' package.json; then
-              ${{ steps.env-info.outputs.runner }} run release-test
-            else
-              node node_modules/semantic-release/bin/semantic-release.js --dry-run
-            fi
+          if [[ "$(jq -r '.dependencies["semantic-release"] != null or .devDependencies["semantic-release"] != null' package.json)" == "true" ]]; then
+            git switch -C "$(jq -r ".branches[0]" .releaserc.json)"
+            ${{ steps.env-info.outputs.runner }} semantic-release --dry-run
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,7 +306,11 @@ jobs:
         run: |
           if [[ "$(jq -r '.dependencies["semantic-release"] != null or .devDependencies["semantic-release"] != null' package.json)" == "true" ]]; then
             git switch -C "$(jq -r ".branches[0]" .releaserc.json)"
-            ${{ steps.env-info.outputs.runner }} semantic-release --dry-run
+            if [[ "$(jq -r '.scripts["release-test"] != null' package.json)" == "true" ]]; then
+              ${{ steps.env-info.outputs.runner }} run release-test
+            else
+              ${{ steps.env-info.outputs.runner }} semantic-release --dry-run
+            fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Run semantic-release dry-run through the detected package runner (`bun` or `yarn`) instead of invoking the Node binary directly.
- Only run the release check when `semantic-release` exists in `dependencies` or `devDependencies`.
- Preserve the existing `release-test` script override when it is defined.

## Verification
- `yarn check-for-ai`
