### PR TITLE
perf: skip yarn cache on self-hosted test runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
             poetry config virtualenvs.in-project true
           fi
 
-      - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.env-info.outputs.yarn-dir }}
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.env-info.outputs.yarn-dir && runner.environment != 'self-hosted' }}
         uses: actions/cache@v5.0.5
         with:
           path: ${{ steps.env-info.outputs.yarn-dir }}


### PR DESCRIPTION
## Summary
- Skip the Yarn v1 actions/cache step on self-hosted test runners.
- Preserve caching for GitHub-hosted runners.

## Verification
- yarn prettier --check .github/workflows/test.yml
