### PR TITLE
ci: run semantic-release dry run with node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -308,6 +308,9 @@ jobs:
             git switch -C "$(jq -r ".branches[0]" .releaserc.json)"
             if grep -q '"release-test":' package.json; then
               ${{ steps.env-info.outputs.runner }} run release-test
+            elif [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+              # Run semantic-release with Node because it checks Node.js runtime requirements.
+              node node_modules/semantic-release/bin/semantic-release.js --dry-run
             else
               ${{ steps.env-info.outputs.runner }} semantic-release --dry-run
             fi


### PR DESCRIPTION
## Customer Summary

- Aligns the test workflow's semantic-release dry run with the release workflow behavior.
- Prevents dry-run checks from depending on a package manager runtime for semantic-release itself.
- No caller workflow changes are required.

## Technical Summary

- Updates the Test workflow's default semantic-release dry-run path for Bun projects.
- Keeps custom `release-test` scripts unchanged.
- Runs `semantic-release` through Node for the default Bun path, matching the Release workflow's semantic-release execution model.

## Why

- semantic-release validates the Node.js runtime it is running under.
- Running semantic-release directly with Node avoids false failures when a package manager runtime does not satisfy that check.

## Testing

- `yarn prettier --check .github/workflows/test.yml`
- `git diff --check`

## Notes

- `actionlint .github/workflows/test.yml` still reports pre-existing workflow warnings outside this change.
