### PR TITLE
ci: fetch the pkg-preflight bootstrap via the authenticated GitHub API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,8 +210,13 @@ jobs:
         name: Inspect dependency lockfile changes
         run: |
           # PkgPreflight is a WillBooster internal service; this uploads changed lockfile contents before install.
-          curl --fail --show-error --silent \
-            "https://raw.githubusercontent.com/${WORKFLOW_REPOSITORY}/${WORKFLOW_SHA}/.github/scripts/create-pkg-preflight-request.cjs" \
+          # Fetch the bootstrap via the authenticated Contents API (5000 req/h/token) instead of anonymous
+          # raw.githubusercontent.com, whose per-IP limit rate-limits shared runners with 429s. Still pinned to
+          # WORKFLOW_SHA for integrity; retry transient failures so a momentary blip doesn't fail the job.
+          curl --fail --show-error --silent --retry 5 --retry-all-errors --retry-delay 2 \
+            -H "authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "accept: application/vnd.github.raw+json" \
+            "https://api.github.com/repos/${WORKFLOW_REPOSITORY}/contents/.github/scripts/create-pkg-preflight-request.cjs?ref=${WORKFLOW_SHA}" \
             --output "$RUNNER_TEMP/create-pkg-preflight-request.cjs"
           node "$RUNNER_TEMP/create-pkg-preflight-request.cjs"
         env:


### PR DESCRIPTION
## Problem

The `Inspect dependency lockfile changes` step in `test.yml` downloads `create-pkg-preflight-request.cjs` **anonymously** from `raw.githubusercontent.com`:

```bash
curl --fail --show-error --silent \
  "https://raw.githubusercontent.com/${WORKFLOW_REPOSITORY}/${WORKFLOW_SHA}/.github/scripts/create-pkg-preflight-request.cjs" ...
```

`raw.githubusercontent.com` has a strict per-IP anonymous rate limit. On shared self-hosted runners this returns **HTTP 429**, and the `curl` has no retry — so the whole Test job fails in ~3s, before dependencies even install. This was observed as a sustained, minutes-long block across `WillBoosterLab` repos (e.g. `ai-game-builder` PR #648, where 4 reruns over ~25 min all 429'd on this exact fetch).

## Fix

Fetch the bootstrap through the **authenticated Contents API** instead:

- `api.github.com/repos/.../contents/...?ref=<sha>` with `Accept: application/vnd.github.raw+json` returns the raw script.
- Authenticated requests get **5,000/hour per token** vs the anonymous raw limit. The step already exposes `GITHUB_TOKEN` (`secrets.GH_TOKEN`), so no new secret is needed.
- Still pinned to `WORKFLOW_SHA`, so the executed script stays immutable and git-auditable — no change to the trust model (important for a supply-chain security tool).
- Added `--retry 5 --retry-all-errors --retry-delay 2` so a momentary blip is retried rather than fatal.

## Verification

Ran the exact new `curl` against this repo — exit 0, returns raw JS (not base64/JSON), and `node --check` passes on the result. YAML validated.

## Note

`WillBoosterLab/reusable-workflows` carries an identical copy of this step and needs the same change for `WillBoosterLab` repos' CI to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)