### PR TITLE
chore: apply wbfy

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -7,47 +7,36 @@ alwaysApply: true
 ## Project Information
 
 - Name: `reusable-workflows`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
-- If you need Railway project information, see the workflow settings in `.github/workflows`.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
+- Railway project information is in the deploy workflows under `.github/workflows`.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -2,18 +2,12 @@ Review in English based on the following coding standards.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,36 @@
 ## Project Information
 
 - Name: `reusable-workflows`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
-- If you need Railway project information, see the workflow settings in `.github/workflows`.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
+- Railway project information is in the deploy workflows under `.github/workflows`.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,36 @@
 ## Project Information
 
 - Name: `reusable-workflows`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
-- If you need Railway project information, see the workflow settings in `.github/workflows`.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
+- Railway project information is in the deploy workflows under `.github/workflows`.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,47 +1,36 @@
 ## Project Information
 
 - Name: `reusable-workflows`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
-- If you need Railway project information, see the workflow settings in `.github/workflows`.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
+- Railway project information is in the deploy workflows under `.github/workflows`.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # reusable-workflows
 
 [![Test](https://github.com/WillBooster/reusable-workflows/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/reusable-workflows/actions/workflows/test.yml)
+[![Test rust](https://github.com/WillBooster/reusable-workflows/actions/workflows/test-rust.yml/badge.svg)](https://github.com/WillBooster/reusable-workflows/actions/workflows/test-rust.yml)
 [![Deploy](https://github.com/WillBooster/reusable-workflows/actions/workflows/deploy.yml/badge.svg)](https://github.com/WillBooster/reusable-workflows/actions/workflows/deploy.yml)
 
 A collection of reusable workflows for GitHub Actions.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ post-merge:
 pre-commit:
   jobs:
     - name: cleanup
-      glob: '**/*.{}'
+      glob: '**/*.{java}'
       run: |-
         # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "verify-full": "wb verify --full"
   },
   "devDependencies": {
-    "@willbooster/wb": "13.25.0",
-    "lefthook": "2.1.9",
+    "@willbooster/wb": "13.27.0",
+    "lefthook": "2.1.10",
     "one-way-git-sync": "6.0.43",
     "sort-package-json": "4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@willbooster/wb@npm:13.25.0":
-  version: 13.25.0
-  resolution: "@willbooster/wb@npm:13.25.0"
+"@willbooster/wb@npm:13.27.0":
+  version: 13.27.0
+  resolution: "@willbooster/wb@npm:13.27.0"
   dependencies:
     chalk: "npm:5.6.2"
     dotenv: "npm:17.4.2"
@@ -92,7 +92,7 @@ __metadata:
     yargs: "npm:18.0.0"
   bin:
     wb: bin/index.js
-  checksum: 10c0/381ec4bf22d8972c2a018fc9a5447ce56fdd7309cdafa472fbb9241cef58e932223f3f3cfe1e8cc83fc0d77cf478d2b796fc41126cdc2766f5fd379a2c83ad60
+  checksum: 10c0/1c38cc7bcaf08aafa71aa7a37dd42b92fa4621bf24a725c972dd039f375a1faf9aee85d307ea60a236b7c01050eb9d4da6342343dacc28516aff65c16a189b9b
   languageName: node
   linkType: hard
 
@@ -439,90 +439,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lefthook-darwin-arm64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-darwin-arm64@npm:2.1.9"
+"lefthook-darwin-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-arm64@npm:2.1.10"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-darwin-x64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-darwin-x64@npm:2.1.9"
+"lefthook-darwin-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-x64@npm:2.1.10"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-freebsd-arm64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-freebsd-arm64@npm:2.1.9"
+"lefthook-freebsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-arm64@npm:2.1.10"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-freebsd-x64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-freebsd-x64@npm:2.1.9"
+"lefthook-freebsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-x64@npm:2.1.10"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-linux-arm64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-linux-arm64@npm:2.1.9"
+"lefthook-linux-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-arm64@npm:2.1.10"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-linux-x64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-linux-x64@npm:2.1.9"
+"lefthook-linux-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-x64@npm:2.1.10"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-openbsd-arm64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-openbsd-arm64@npm:2.1.9"
+"lefthook-openbsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-arm64@npm:2.1.10"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-openbsd-x64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-openbsd-x64@npm:2.1.9"
+"lefthook-openbsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-x64@npm:2.1.10"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-windows-arm64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-windows-arm64@npm:2.1.9"
+"lefthook-windows-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-arm64@npm:2.1.10"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-windows-x64@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook-windows-x64@npm:2.1.9"
+"lefthook-windows-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-x64@npm:2.1.10"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook@npm:2.1.9":
-  version: 2.1.9
-  resolution: "lefthook@npm:2.1.9"
+"lefthook@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook@npm:2.1.10"
   dependencies:
-    lefthook-darwin-arm64: "npm:2.1.9"
-    lefthook-darwin-x64: "npm:2.1.9"
-    lefthook-freebsd-arm64: "npm:2.1.9"
-    lefthook-freebsd-x64: "npm:2.1.9"
-    lefthook-linux-arm64: "npm:2.1.9"
-    lefthook-linux-x64: "npm:2.1.9"
-    lefthook-openbsd-arm64: "npm:2.1.9"
-    lefthook-openbsd-x64: "npm:2.1.9"
-    lefthook-windows-arm64: "npm:2.1.9"
-    lefthook-windows-x64: "npm:2.1.9"
+    lefthook-darwin-arm64: "npm:2.1.10"
+    lefthook-darwin-x64: "npm:2.1.10"
+    lefthook-freebsd-arm64: "npm:2.1.10"
+    lefthook-freebsd-x64: "npm:2.1.10"
+    lefthook-linux-arm64: "npm:2.1.10"
+    lefthook-linux-x64: "npm:2.1.10"
+    lefthook-openbsd-arm64: "npm:2.1.10"
+    lefthook-openbsd-x64: "npm:2.1.10"
+    lefthook-windows-arm64: "npm:2.1.10"
+    lefthook-windows-x64: "npm:2.1.10"
   dependenciesMeta:
     lefthook-darwin-arm64:
       optional: true
@@ -546,7 +546,7 @@ __metadata:
       optional: true
   bin:
     lefthook: bin/index.js
-  checksum: 10c0/676d9798942439d1cd5373bb0b2c9907f6a8097b29c05cc028d87d897d2a2cfe15a8f7e4f40b02fa93cd1ae0f02528f24053a10fb5c5967210a9c23f3c7b5059
+  checksum: 10c0/be812e1517a967977750a41f15a2070cea63e1774137737426f636e1bd379f4dfc73482fa7f07df6b9a1413ee50c6e2d790936d7986bdcafd46255d871c17b76
   languageName: node
   linkType: hard
 
@@ -743,8 +743,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "reusable-workflows@workspace:."
   dependencies:
-    "@willbooster/wb": "npm:13.25.0"
-    lefthook: "npm:2.1.9"
+    "@willbooster/wb": "npm:13.27.0"
+    lefthook: "npm:2.1.10"
     one-way-git-sync: "npm:6.0.43"
     sort-package-json: "npm:4.0.0"
   languageName: unknown


### PR DESCRIPTION
Re-apply `wbfy` to this repo, primarily to verify that `wbfy` no longer creates a **Protect main** ruleset here (WillBooster/shared#938).

## Verified behavior
- `repos/WillBooster/reusable-workflows/rulesets` stays `[]` after running `wbfy` — the ruleset step is now correctly skipped for the reusable-workflows repo.
- `.github/workflows/` is left untouched (workflow generation was already skipped).

## Incidental wbfy updates
- `@willbooster/wb` 13.25.0 → 13.27.0, `lefthook` 2.1.9 → 2.1.10
- `lefthook.yml` glob fix (`**/*.{}` → `**/*.{java}`)
- Regenerated agent docs (AGENTS.md, CLAUDE.md, GEMINI.md, .cursor, .gemini, README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
