### PR TITLE
feat: add reusable run-script workflow for scheduled maintenance jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,8 @@ jobs:
       FORCE_COLOR: 3
       # constants
       PYTHON_VERSION: 3.13.9
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/credentials.json
+      # Unique per run: shared self-hosted runners can execute jobs concurrently.
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/credentials-${{ github.run_id }}-${{ github.run_attempt }}.json
       # arguments
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
@@ -110,17 +111,20 @@ jobs:
       # Secrets are passed via env and written with printf so that quotes or backslashes in
       # their values cannot break out of the shell command.
       - if: ${{ env.HAS_DOT_ENV == 'true' }}
-        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        run: printf '%s\n' "$DOT_ENV" > "$DOT_ENV_PATH"
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
       - if: ${{ inputs.file_path_1 }}
-        run: printf '%s\n' "$FILE_CONTENT_1" > "${{ inputs.file_path_1 }}"
+        run: printf '%s\n' "$FILE_CONTENT_1" > "$FILE_PATH_1"
         env:
           FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
+          FILE_PATH_1: ${{ inputs.file_path_1 }}
       - if: ${{ inputs.file_path_2 }}
-        run: printf '%s\n' "$FILE_CONTENT_2" > "${{ inputs.file_path_2 }}"
+        run: printf '%s\n' "$FILE_CONTENT_2" > "$FILE_PATH_2"
         env:
           FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
+          FILE_PATH_2: ${{ inputs.file_path_2 }}
 
       - name: Check version files
         id: check-ver
@@ -301,15 +305,15 @@ jobs:
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
         run: |
           node -e '
-            const { MENTION, REPO_LINK, ENVIRONMENT, SERVER_URL, COMMIT_LINK, WORKFLOW_URL } = process.env;
+            const { MENTION = "", REPO_LINK = "", ENVIRONMENT = "", SERVER_URL = "", COMMIT_LINK = "", WORKFLOW_URL = "" } = process.env;
             console.log(JSON.stringify({
               username: "WillBooster Bot",
               avatar_url: "https://avatars.githubusercontent.com/u/98675783",
               content: `${MENTION} ${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しようとして、[失敗](${WORKFLOW_URL})しました！！！`,
             }));
-          ' > /tmp/discord-payload.json
-          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
-          rm -f /tmp/discord-payload.json
+          ' > "$RUNNER_TEMP/discord-payload.json"
+          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           MENTION: ${{ inputs.failure_mention_on_discord }}
           ENVIRONMENT: ${{ inputs.environment }}
@@ -318,15 +322,15 @@ jobs:
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment != 'production' }}
         run: |
           node -e '
-            const { REPO_LINK, ENVIRONMENT, SERVER_URL, COMMIT_LINK } = process.env;
+            const { REPO_LINK = "", ENVIRONMENT = "", SERVER_URL = "", COMMIT_LINK = "" } = process.env;
             console.log(JSON.stringify({
               username: "WillBooster Bot",
               avatar_url: "https://avatars.githubusercontent.com/u/98675783",
               content: `${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。`,
             }));
-          ' > /tmp/discord-payload.json
-          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
-          rm -f /tmp/discord-payload.json
+          ' > "$RUNNER_TEMP/discord-payload.json"
+          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           ENVIRONMENT: ${{ inputs.environment }}
           SERVER_URL: ${{ inputs.server_url }}
@@ -334,15 +338,15 @@ jobs:
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment == 'production' }}
         run: |
           node -e '
-            const { REPO_LINK, SERVER_URL, COMMIT_LINK } = process.env;
+            const { REPO_LINK = "", SERVER_URL = "", COMMIT_LINK = "" } = process.env;
             console.log(JSON.stringify({
               username: "WillBooster Bot",
               avatar_url: "https://avatars.githubusercontent.com/u/98675783",
               content: `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n${REPO_LINK} の本番環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`,
             }));
-          ' > /tmp/discord-payload.json
-          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
-          rm -f /tmp/discord-payload.json
+          ' > "$RUNNER_TEMP/discord-payload.json"
+          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           SERVER_URL: ${{ inputs.server_url }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -350,9 +354,15 @@ jobs:
       - if: ${{ always() }}
         name: Delete credential files
         run: |
-          rm -f -- "$GOOGLE_APPLICATION_CREDENTIALS" "${{ inputs.dot_env_path }}"
-          if [[ -n "${{ inputs.file_path_1 }}" ]]; then rm -f -- "${{ inputs.file_path_1 }}"; fi
-          if [[ -n "${{ inputs.file_path_2 }}" ]]; then rm -f -- "${{ inputs.file_path_2 }}"; fi
+          rm -f -- "$GOOGLE_APPLICATION_CREDENTIALS"
+          : # Delete the dotenv only when this run wrote it: some private repos commit .env.
+          if [[ "$HAS_DOT_ENV" == "true" ]]; then rm -f -- "$DOT_ENV_PATH"; fi
+          if [[ -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
+          if [[ -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
+        env:
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+          FILE_PATH_1: ${{ inputs.file_path_1 }}
+          FILE_PATH_2: ${{ inputs.file_path_2 }}
       - if: ${{ always() }}
         name: Clean up pyc files and docker
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,12 +107,20 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
+      # Secrets are passed via env and written with printf so that quotes or backslashes in
+      # their values cannot break out of the shell command.
       - if: ${{ env.HAS_DOT_ENV == 'true' }}
-        run: echo '${{ secrets.DOT_ENV }}' > ${{ inputs.dot_env_path }}
+        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        env:
+          DOT_ENV: ${{ secrets.DOT_ENV }}
       - if: ${{ inputs.file_path_1 }}
-        run: echo '${{ secrets.FILE_CONTENT_1 }}' > ${{ inputs.file_path_1 }}
+        run: printf '%s\n' "$FILE_CONTENT_1" > "${{ inputs.file_path_1 }}"
+        env:
+          FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
       - if: ${{ inputs.file_path_2 }}
-        run: echo '${{ secrets.FILE_CONTENT_2 }}' > ${{ inputs.file_path_2 }}
+        run: printf '%s\n' "$FILE_CONTENT_2" > "${{ inputs.file_path_2 }}"
+        env:
+          FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
 
       - name: Check version files
         id: check-ver
@@ -288,37 +296,63 @@ jobs:
           echo "REPO_LINK=[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" >> $GITHUB_ENV
           echo "COMMIT_LINK=[$WB_VERSION](https://github.com/${{ github.repository }}/commits/$WB_VERSION)" >> $GITHUB_ENV
           echo "WORKFLOW_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+      # Payloads are built with node's JSON.stringify from env values so that quotes or
+      # backslashes in inputs can neither break the JSON nor inject shell commands.
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
         run: |
-          curl -X POST -H "Content-Type: application/json" \
-               --data "{
-                  \"username\": \"WillBooster Bot\",
-                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"${{inputs.failure_mention_on_discord}} $REPO_LINK の${{inputs.environment}}環境 (${{ inputs.server_url }}) を $COMMIT_LINK に更新しようとして、[失敗]($WORKFLOW_URL)しました！！！\"
-               }" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+          node -e '
+            const { MENTION, REPO_LINK, ENVIRONMENT, SERVER_URL, COMMIT_LINK, WORKFLOW_URL } = process.env;
+            console.log(JSON.stringify({
+              username: "WillBooster Bot",
+              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
+              content: `${MENTION} ${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しようとして、[失敗](${WORKFLOW_URL})しました！！！`,
+            }));
+          ' > /tmp/discord-payload.json
+          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
+          rm -f /tmp/discord-payload.json
+        env:
+          MENTION: ${{ inputs.failure_mention_on_discord }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SERVER_URL: ${{ inputs.server_url }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment != 'production' }}
         run: |
-          curl -X POST -H "Content-Type: application/json" \
-               --data "{
-                  \"username\": \"WillBooster Bot\",
-                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"$REPO_LINK の${{inputs.environment}}環境 (${{ inputs.server_url }}) を $COMMIT_LINK に更新しました。\"
-               }" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+          node -e '
+            const { REPO_LINK, ENVIRONMENT, SERVER_URL, COMMIT_LINK } = process.env;
+            console.log(JSON.stringify({
+              username: "WillBooster Bot",
+              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
+              content: `${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。`,
+            }));
+          ' > /tmp/discord-payload.json
+          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
+          rm -f /tmp/discord-payload.json
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          SERVER_URL: ${{ inputs.server_url }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment == 'production' }}
         run: |
-          curl -X POST -H "Content-Type: application/json" \
-               --data "{
-                  \"username\": \"WillBooster Bot\",
-                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n$REPO_LINK の本番環境 (${{ inputs.server_url }}) を $COMMIT_LINK に更新しました。\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\"
-               }" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+          node -e '
+            const { REPO_LINK, SERVER_URL, COMMIT_LINK } = process.env;
+            console.log(JSON.stringify({
+              username: "WillBooster Bot",
+              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
+              content: `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n${REPO_LINK} の本番環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`,
+            }));
+          ' > /tmp/discord-payload.json
+          curl -X POST -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
+          rm -f /tmp/discord-payload.json
+        env:
+          SERVER_URL: ${{ inputs.server_url }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       - if: ${{ always() }}
         name: Delete credential files
-        run: rm -f $GOOGLE_APPLICATION_CREDENTIALS ${{ inputs.dot_env_path }}
+        run: |
+          rm -f -- "$GOOGLE_APPLICATION_CREDENTIALS" "${{ inputs.dot_env_path }}"
+          if [[ -n "${{ inputs.file_path_1 }}" ]]; then rm -f -- "${{ inputs.file_path_1 }}"; fi
+          if [[ -n "${{ inputs.file_path_2 }}" ]]; then rm -f -- "${{ inputs.file_path_2 }}"; fi
       - if: ${{ always() }}
         name: Clean up pyc files and docker
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,7 +323,7 @@ jobs:
               content: `${MENTION} ${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しようとして、[失敗](${WORKFLOW_URL})しました！！！`,
             }));
           ' > "$RUNNER_TEMP/discord-payload.json"
-          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           MENTION: ${{ inputs.failure_mention_on_discord }}
@@ -340,7 +340,7 @@ jobs:
               content: `${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。`,
             }));
           ' > "$RUNNER_TEMP/discord-payload.json"
-          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           ENVIRONMENT: ${{ inputs.environment }}
@@ -356,7 +356,7 @@ jobs:
               content: `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n${REPO_LINK} の本番環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`,
             }));
           ' > "$RUNNER_TEMP/discord-payload.json"
-          curl -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           SERVER_URL: ${{ inputs.server_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -311,56 +311,39 @@ jobs:
           VERSION_FOR_LINK="${WB_VERSION:-$(git describe --always --tags 2> /dev/null || echo '${{ github.sha }}')}"
           echo "COMMIT_LINK=[$VERSION_FOR_LINK](https://github.com/${{ github.repository }}/commits/$VERSION_FOR_LINK)" >> $GITHUB_ENV
           echo "WORKFLOW_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
-      # Payloads are built with node's JSON.stringify from env values so that quotes or
-      # backslashes in inputs can neither break the JSON nor inject shell commands.
+      # Payload contents are JSON-escaped by GitHub's toJSON expression and inserted with
+      # printf, so quotes/backslashes in inputs cannot break the JSON or the shell, and the
+      # failure notifier needs no provisioned tools (an early failure may precede setup-node).
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
         run: |
-          node -e '
-            const { MENTION = "", REPO_LINK = "", ENVIRONMENT = "", SERVER_URL = "", COMMIT_LINK = "", WORKFLOW_URL = "" } = process.env;
-            console.log(JSON.stringify({
-              username: "WillBooster Bot",
-              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
-              content: `${MENTION} ${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しようとして、[失敗](${WORKFLOW_URL})しました！！！`,
-            }));
-          ' > "$RUNNER_TEMP/discord-payload.json"
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
           curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          MENTION: ${{ inputs.failure_mention_on_discord }}
-          ENVIRONMENT: ${{ inputs.environment }}
-          SERVER_URL: ${{ inputs.server_url }}
+          CONTENT_JSON: ${{ toJSON(format('{0} {1} の{2}環境 ({3}) を {4} に更新しようとして、[失敗]({5})しました！！！', inputs.failure_mention_on_discord, env.REPO_LINK, inputs.environment, inputs.server_url, env.COMMIT_LINK, env.WORKFLOW_URL)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment != 'production' }}
         run: |
-          node -e '
-            const { REPO_LINK = "", ENVIRONMENT = "", SERVER_URL = "", COMMIT_LINK = "" } = process.env;
-            console.log(JSON.stringify({
-              username: "WillBooster Bot",
-              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
-              content: `${REPO_LINK} の${ENVIRONMENT}環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。`,
-            }));
-          ' > "$RUNNER_TEMP/discord-payload.json"
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
           curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          ENVIRONMENT: ${{ inputs.environment }}
-          SERVER_URL: ${{ inputs.server_url }}
+          CONTENT_JSON: ${{ toJSON(format('{0} の{1}環境 ({2}) を {3} に更新しました。', env.REPO_LINK, inputs.environment, inputs.server_url, env.COMMIT_LINK)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && inputs.environment == 'production' }}
         run: |
-          node -e '
-            const { REPO_LINK = "", SERVER_URL = "", COMMIT_LINK = "" } = process.env;
-            console.log(JSON.stringify({
-              username: "WillBooster Bot",
-              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
-              content: `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n${REPO_LINK} の本番環境 (${SERVER_URL}) を ${COMMIT_LINK} に更新しました。\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`,
-            }));
-          ' > "$RUNNER_TEMP/discord-payload.json"
+          CONTENT_JSON="${CONTENT_JSON//<br>/\\n}"
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
           curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          SERVER_URL: ${{ inputs.server_url }}
+          # <br> placeholders become JSON \n escapes in the run block (GitHub expression
+          # literals cannot contain real newlines).
+          CONTENT_JSON: ${{ toJSON(format('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!<br>{0} の本番環境 ({1}) を {2} に更新しました。<br>!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!', env.REPO_LINK, inputs.server_url, env.COMMIT_LINK)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
 
       - if: ${{ always() }}
         name: Delete credential files

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,7 +307,9 @@ jobs:
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && always() }}
         run: |
           echo "REPO_LINK=[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" >> $GITHUB_ENV
-          echo "COMMIT_LINK=[$WB_VERSION](https://github.com/${{ github.repository }}/commits/$WB_VERSION)" >> $GITHUB_ENV
+          : # WB_VERSION is set by a later step; fall back so early failures still get a usable link.
+          VERSION_FOR_LINK="${WB_VERSION:-$(git describe --always --tags 2> /dev/null || echo '${{ github.sha }}')}"
+          echo "COMMIT_LINK=[$VERSION_FOR_LINK](https://github.com/${{ github.repository }}/commits/$VERSION_FOR_LINK)" >> $GITHUB_ENV
           echo "WORKFLOW_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
       # Payloads are built with node's JSON.stringify from env values so that quotes or
       # backslashes in inputs can neither break the JSON nor inject shell commands.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,13 +92,13 @@ jobs:
       FORCE_COLOR: 3
       # constants
       PYTHON_VERSION: 3.13.9
-      # Unique per run: shared self-hosted runners can execute jobs concurrently.
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/credentials-${{ github.run_id }}-${{ github.run_attempt }}.json
       # arguments
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_FLY_API_TOKEN: ${{ !!secrets.FLY_API_TOKEN }}
       HAS_GCP_SA_KEY_JSON: ${{ !!secrets.GCP_SA_KEY_JSON }}
+      HAS_FILE_CONTENT_1: ${{ !!secrets.FILE_CONTENT_1 }}
+      HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
       HAS_GCP_SA_KEY_JSON_FOR_FIREBASE: ${{ !!secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}
       HAS_RAILWAY_API_TOKEN: ${{ !!secrets.RAILWAY_API_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
@@ -115,12 +115,12 @@ jobs:
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
-      - if: ${{ inputs.file_path_1 }}
+      - if: ${{ inputs.file_path_1 && env.HAS_FILE_CONTENT_1 == 'true' }}
         run: printf '%s\n' "$FILE_CONTENT_1" > "$FILE_PATH_1"
         env:
           FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}
-      - if: ${{ inputs.file_path_2 }}
+      - if: ${{ inputs.file_path_2 && env.HAS_FILE_CONTENT_2 == 'true' }}
         run: printf '%s\n' "$FILE_CONTENT_2" > "$FILE_PATH_2"
         env:
           FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
@@ -254,7 +254,14 @@ jobs:
 
       - if: ${{ env.HAS_GCP_SA_KEY_JSON_FOR_FIREBASE == 'true' }}
         name: Create credential file for Firebase
-        run: echo '${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}' > $GOOGLE_APPLICATION_CREDENTIALS
+        # mktemp under RUNNER_TEMP keeps the path job-unique (matrix jobs share run_id) and
+        # the secret goes through env + printf so its content cannot break out of the shell.
+        run: |
+          GOOGLE_APPLICATION_CREDENTIALS="$(mktemp "$RUNNER_TEMP/credentials.XXXXXX")"
+          printf '%s\n' "$GCP_SA_KEY_JSON_FOR_FIREBASE" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS" >> "$GITHUB_ENV"
+        env:
+          GCP_SA_KEY_JSON_FOR_FIREBASE: ${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}
 
       - name: Run "common/ci-setup" npm script if exists
         run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
@@ -295,6 +302,8 @@ jobs:
         env:
           SERVER_URL: ${{ inputs.server_url }}
 
+      # always(): runs even when an earlier step failed, so the failure notification below
+      # always has REPO_LINK/COMMIT_LINK/WORKFLOW_URL available.
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && always() }}
         run: |
           echo "REPO_LINK=[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" >> $GITHUB_ENV
@@ -354,11 +363,12 @@ jobs:
       - if: ${{ always() }}
         name: Delete credential files
         run: |
-          rm -f -- "$GOOGLE_APPLICATION_CREDENTIALS"
-          : # Delete the dotenv only when this run wrote it: some private repos commit .env.
+          if [[ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then rm -f -- "$GOOGLE_APPLICATION_CREDENTIALS"; fi
+          : # Delete each file only when this run actually wrote it (the caller may commit
+          : # files at these paths and run without the corresponding secret).
           if [[ "$HAS_DOT_ENV" == "true" ]]; then rm -f -- "$DOT_ENV_PATH"; fi
-          if [[ -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
-          if [[ -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
+          if [[ "$HAS_FILE_CONTENT_1" == "true" && -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
+          if [[ "$HAS_FILE_CONTENT_2" == "true" && -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -188,29 +188,18 @@ jobs:
           COMMAND_ARGS: ${{ inputs.command_args }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
-      # The payload is built with node's JSON.stringify from env values so that quotes or
-      # backslashes in inputs can neither break the JSON nor inject shell commands.
+      # The payload content is JSON-escaped by GitHub's toJSON expression and inserted with
+      # printf, so quotes/backslashes in inputs cannot break the JSON or the shell, and the
+      # notifier needs no provisioned tools (an early failure may precede setup-node/mise).
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
         run: |
-          REPO_LINK="[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" \
-          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-          node -e '
-            const { MENTION = "", REPO_LINK = "", COMMAND = "", ENVIRONMENT = "", WORKFLOW_URL = "" } = process.env;
-            const environmentSuffix = ENVIRONMENT ? ` (${ENVIRONMENT})` : "";
-            console.log(JSON.stringify({
-              username: "WillBooster Bot",
-              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
-              content: `${MENTION} ${REPO_LINK} の ${COMMAND}${environmentSuffix} が[失敗](${WORKFLOW_URL})しました！！！`,
-            }));
-          ' > "$RUNNER_TEMP/discord-payload.json"
-          curl --fail-with-body -X POST -H "Content-Type: application/json" \
-               --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          MENTION: ${{ inputs.failure_mention_on_discord }}
-          COMMAND: ${{ inputs.command }}
-          ENVIRONMENT: ${{ inputs.environment }}
+          CONTENT_JSON: ${{ toJSON(format('{0} [{1}]({2}) の {3}{4} が[失敗](https://github.com/{5}/actions/runs/{6})しました！！！', inputs.failure_mention_on_discord, github.event.repository.name, github.event.repository.html_url, inputs.command, (inputs.environment && format(' ({0})', inputs.environment)) || '', github.repository, github.run_id)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
 
       - if: ${{ always() }}
         name: Delete credential files

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -80,6 +80,8 @@ jobs:
       FORCE_COLOR: 3
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
+      HAS_FILE_CONTENT_1: ${{ !!secrets.FILE_CONTENT_1 }}
+      HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
       WB_ENV: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v7.0.0
@@ -92,12 +94,12 @@ jobs:
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
-      - if: ${{ inputs.file_path_1 }}
+      - if: ${{ inputs.file_path_1 && env.HAS_FILE_CONTENT_1 == 'true' }}
         run: printf '%s\n' "$FILE_CONTENT_1" > "$FILE_PATH_1"
         env:
           FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}
-      - if: ${{ inputs.file_path_2 }}
+      - if: ${{ inputs.file_path_2 && env.HAS_FILE_CONTENT_2 == 'true' }}
         run: printf '%s\n' "$FILE_CONTENT_2" > "$FILE_PATH_2"
         env:
           FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
@@ -192,10 +194,11 @@ jobs:
           WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           node -e '
             const { MENTION = "", REPO_LINK = "", COMMAND = "", ENVIRONMENT = "", WORKFLOW_URL = "" } = process.env;
+            const environmentSuffix = ENVIRONMENT ? ` (${ENVIRONMENT})` : "";
             console.log(JSON.stringify({
               username: "WillBooster Bot",
               avatar_url: "https://avatars.githubusercontent.com/u/98675783",
-              content: `${MENTION} ${REPO_LINK} の ${COMMAND} (${ENVIRONMENT}) が[失敗](${WORKFLOW_URL})しました！！！`,
+              content: `${MENTION} ${REPO_LINK} の ${COMMAND}${environmentSuffix} が[失敗](${WORKFLOW_URL})しました！！！`,
             }));
           ' > "$RUNNER_TEMP/discord-payload.json"
           curl --fail-with-body -X POST -H "Content-Type: application/json" \
@@ -210,10 +213,11 @@ jobs:
       - if: ${{ always() }}
         name: Delete credential files
         run: |
-          : # Delete the dotenv only when this run wrote it: some private repos commit .env.
+          : # Delete each file only when this run actually wrote it (the caller may commit
+          : # files at these paths and run without the corresponding secret).
           if [[ "$HAS_DOT_ENV" == "true" ]]; then rm -f -- "$DOT_ENV_PATH"; fi
-          if [[ -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
-          if [[ -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
+          if [[ "$HAS_FILE_CONTENT_1" == "true" && -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
+          if [[ "$HAS_FILE_CONTENT_2" == "true" && -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -18,7 +18,8 @@ on:
         required: true
         type: string
       command_args:
-        # Extra arguments appended to the script invocation (after `--`).
+        # Extra arguments appended to the script invocation. Whitespace-split; arguments
+        # containing spaces or shell metacharacters are not supported.
         required: false
         type: string
       cpu_arch:
@@ -87,17 +88,20 @@ jobs:
       # Secrets are passed via env and written with printf so that quotes or backslashes in
       # their values cannot break out of the shell command.
       - if: ${{ env.HAS_DOT_ENV == 'true' }}
-        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        run: printf '%s\n' "$DOT_ENV" > "$DOT_ENV_PATH"
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
       - if: ${{ inputs.file_path_1 }}
-        run: printf '%s\n' "$FILE_CONTENT_1" > "${{ inputs.file_path_1 }}"
+        run: printf '%s\n' "$FILE_CONTENT_1" > "$FILE_PATH_1"
         env:
           FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
+          FILE_PATH_1: ${{ inputs.file_path_1 }}
       - if: ${{ inputs.file_path_2 }}
-        run: printf '%s\n' "$FILE_CONTENT_2" > "${{ inputs.file_path_2 }}"
+        run: printf '%s\n' "$FILE_CONTENT_2" > "$FILE_PATH_2"
         env:
           FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
+          FILE_PATH_2: ${{ inputs.file_path_2 }}
 
       - name: Check version files
         id: check-ver
@@ -173,11 +177,8 @@ jobs:
         # Step-level so that the always() credential cleanup below still runs on timeout.
         timeout-minutes: ${{ inputs.timeout_minutes }}
         run: |
-          if [[ -n "$COMMAND_ARGS" ]]; then
-            ${{ steps.env-info.outputs.runner }} run "$COMMAND" -- $COMMAND_ARGS
-          else
-            ${{ steps.env-info.outputs.runner }} run "$COMMAND"
-          fi
+          set -f # COMMAND_ARGS is whitespace-split into arguments; no glob expansion.
+          ${{ steps.env-info.outputs.runner }} run "$COMMAND" $COMMAND_ARGS
         env:
           COMMAND: ${{ inputs.command }}
           COMMAND_ARGS: ${{ inputs.command_args }}
@@ -190,16 +191,16 @@ jobs:
           REPO_LINK="[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" \
           WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           node -e '
-            const { MENTION, REPO_LINK, COMMAND, ENVIRONMENT, WORKFLOW_URL } = process.env;
+            const { MENTION = "", REPO_LINK = "", COMMAND = "", ENVIRONMENT = "", WORKFLOW_URL = "" } = process.env;
             console.log(JSON.stringify({
               username: "WillBooster Bot",
               avatar_url: "https://avatars.githubusercontent.com/u/98675783",
               content: `${MENTION} ${REPO_LINK} の ${COMMAND} (${ENVIRONMENT}) が[失敗](${WORKFLOW_URL})しました！！！`,
             }));
-          ' > /tmp/discord-payload.json
+          ' > "$RUNNER_TEMP/discord-payload.json"
           curl --fail-with-body -X POST -H "Content-Type: application/json" \
-               --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
-          rm -f /tmp/discord-payload.json
+               --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           MENTION: ${{ inputs.failure_mention_on_discord }}
           COMMAND: ${{ inputs.command }}
@@ -209,6 +210,11 @@ jobs:
       - if: ${{ always() }}
         name: Delete credential files
         run: |
-          rm -f -- "${{ inputs.dot_env_path }}"
-          if [[ -n "${{ inputs.file_path_1 }}" ]]; then rm -f -- "${{ inputs.file_path_1 }}"; fi
-          if [[ -n "${{ inputs.file_path_2 }}" ]]; then rm -f -- "${{ inputs.file_path_2 }}"; fi
+          : # Delete the dotenv only when this run wrote it: some private repos commit .env.
+          if [[ "$HAS_DOT_ENV" == "true" ]]; then rm -f -- "$DOT_ENV_PATH"; fi
+          if [[ -n "$FILE_PATH_1" ]]; then rm -f -- "$FILE_PATH_1"; fi
+          if [[ -n "$FILE_PATH_2" ]]; then rm -f -- "$FILE_PATH_2"; fi
+        env:
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+          FILE_PATH_1: ${{ inputs.file_path_1 }}
+          FILE_PATH_2: ${{ inputs.file_path_2 }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -53,6 +53,7 @@ on:
         required: false
         type: string
       timeout_minutes:
+        # Timeout for the "Run script" step only, so the credential cleanup still runs.
         default: 60
         required: false
         type: number
@@ -74,7 +75,6 @@ jobs:
   run-script:
     if: ${{ !inputs.target_organization || github.repository_owner == inputs.target_organization }}
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || (inputs.cpu_arch && fromJSON(format('["self-hosted", "{0}", "{1}"]', inputs.ci_label, inputs.cpu_arch))) || fromJSON(format('["self-hosted", "{0}"]', inputs.ci_label)) }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       FORCE_COLOR: 3
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
@@ -84,12 +84,20 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
+      # Secrets are passed via env and written with printf so that quotes or backslashes in
+      # their values cannot break out of the shell command.
       - if: ${{ env.HAS_DOT_ENV == 'true' }}
-        run: echo '${{ secrets.DOT_ENV }}' > ${{ inputs.dot_env_path }}
+        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        env:
+          DOT_ENV: ${{ secrets.DOT_ENV }}
       - if: ${{ inputs.file_path_1 }}
-        run: echo '${{ secrets.FILE_CONTENT_1 }}' > ${{ inputs.file_path_1 }}
+        run: printf '%s\n' "$FILE_CONTENT_1" > "${{ inputs.file_path_1 }}"
+        env:
+          FILE_CONTENT_1: ${{ secrets.FILE_CONTENT_1 }}
       - if: ${{ inputs.file_path_2 }}
-        run: echo '${{ secrets.FILE_CONTENT_2 }}' > ${{ inputs.file_path_2 }}
+        run: printf '%s\n' "$FILE_CONTENT_2" > "${{ inputs.file_path_2 }}"
+        env:
+          FILE_CONTENT_2: ${{ secrets.FILE_CONTENT_2 }}
 
       - name: Check version files
         id: check-ver
@@ -158,23 +166,49 @@ jobs:
       - name: Run "common/ci-setup" npm script if exists
         run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
 
+      # The script name and arguments are reusable-workflow inputs; passing them via env keeps
+      # expression interpolation out of the shell script (no command injection). COMMAND_ARGS is
+      # deliberately expanded unquoted so that it word-splits into separate arguments.
       - name: Run script
-        run: ${{ steps.env-info.outputs.runner }} run ${{ inputs.command }} ${{ inputs.command_args && format('-- {0}', inputs.command_args) }}
+        # Step-level so that the always() credential cleanup below still runs on timeout.
+        timeout-minutes: ${{ inputs.timeout_minutes }}
+        run: |
+          if [[ -n "$COMMAND_ARGS" ]]; then
+            ${{ steps.env-info.outputs.runner }} run "$COMMAND" -- $COMMAND_ARGS
+          else
+            ${{ steps.env-info.outputs.runner }} run "$COMMAND"
+          fi
         env:
+          COMMAND: ${{ inputs.command }}
+          COMMAND_ARGS: ${{ inputs.command_args }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
+      # The payload is built with node's JSON.stringify from env values so that quotes or
+      # backslashes in inputs can neither break the JSON nor inject shell commands.
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
         run: |
-          REPO_LINK="[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})"
-          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          curl -X POST -H "Content-Type: application/json" \
-               --data "{
-                  \"username\": \"WillBooster Bot\",
-                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"${{inputs.failure_mention_on_discord}} $REPO_LINK の ${{ inputs.command }} (${{ inputs.environment }}) が[失敗]($WORKFLOW_URL)しました！！！\"
-               }" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPO_LINK="[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})" \
+          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          node -e '
+            const { MENTION, REPO_LINK, COMMAND, ENVIRONMENT, WORKFLOW_URL } = process.env;
+            console.log(JSON.stringify({
+              username: "WillBooster Bot",
+              avatar_url: "https://avatars.githubusercontent.com/u/98675783",
+              content: `${MENTION} ${REPO_LINK} の ${COMMAND} (${ENVIRONMENT}) が[失敗](${WORKFLOW_URL})しました！！！`,
+            }));
+          ' > /tmp/discord-payload.json
+          curl --fail-with-body -X POST -H "Content-Type: application/json" \
+               --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK_URL"
+          rm -f /tmp/discord-payload.json
+        env:
+          MENTION: ${{ inputs.failure_mention_on_discord }}
+          COMMAND: ${{ inputs.command }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       - if: ${{ always() }}
         name: Delete credential files
-        run: rm -f ${{ inputs.dot_env_path }} ${{ inputs.file_path_1 }} ${{ inputs.file_path_2 }}
+        run: |
+          rm -f -- "${{ inputs.dot_env_path }}"
+          if [[ -n "${{ inputs.file_path_1 }}" ]]; then rm -f -- "${{ inputs.file_path_1 }}"; fi
+          if [[ -n "${{ inputs.file_path_2 }}" ]]; then rm -f -- "${{ inputs.file_path_2 }}"; fi

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -159,12 +159,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
       - name: Install dependencies
+        # Unlike deploy.yml/test.yml, install failures are NOT suppressed here: a maintenance
+        # script run against a half-installed dependency graph could silently misbehave.
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install || true # To ignore postinstall errors
+            ${{ steps.env-info.outputs.runner }} install
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,0 +1,180 @@
+name: Run script
+
+# Runs an arbitrary package.json script with the repo's dotenv/secret files in place.
+# Intended for scheduled maintenance jobs (e.g. cleanup scripts) so that caller repos
+# do not duplicate checkout/setup/install boilerplate per job.
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+      ci_label:
+        default: medium
+        required: false
+        type: string
+      command:
+        # Name of the package.json script to run (e.g. cleanup-orphan-r2-objects).
+        required: true
+        type: string
+      command_args:
+        # Extra arguments appended to the script invocation (after `--`).
+        required: false
+        type: string
+      cpu_arch:
+        required: false
+        type: string
+      dot_env_path:
+        default: .env
+        required: false
+        type: string
+      environment:
+        # Exported as WB_ENV when set.
+        required: false
+        type: string
+      file_path_1:
+        required: false
+        type: string
+      file_path_2:
+        required: false
+        type: string
+      github_hosted_runner:
+        required: false
+        type: boolean
+      failure_mention_on_discord:
+        # default value is @exKAZUu
+        default: <@410228643143483402>
+        required: false
+        type: string
+      runs_on:
+        required: false
+        type: string
+      target_organization:
+        required: false
+        type: string
+      timeout_minutes:
+        default: 60
+        required: false
+        type: number
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        required: false
+      DOT_ENV:
+        required: false
+      FILE_CONTENT_1:
+        required: false
+      FILE_CONTENT_2:
+        required: false
+      GH_TOKEN:
+        required: false
+      GH_PKG_READ_TOKEN:
+        required: false
+
+jobs:
+  run-script:
+    if: ${{ !inputs.target_organization || github.repository_owner == inputs.target_organization }}
+    runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || (inputs.cpu_arch && fromJSON(format('["self-hosted", "{0}", "{1}"]', inputs.ci_label, inputs.cpu_arch))) || fromJSON(format('["self-hosted", "{0}"]', inputs.ci_label)) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    env:
+      FORCE_COLOR: 3
+      HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
+      HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
+      WB_ENV: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.branch }}
+      - if: ${{ env.HAS_DOT_ENV == 'true' }}
+        run: echo '${{ secrets.DOT_ENV }}' > ${{ inputs.dot_env_path }}
+      - if: ${{ inputs.file_path_1 }}
+        run: echo '${{ secrets.FILE_CONTENT_1 }}' > ${{ inputs.file_path_1 }}
+      - if: ${{ inputs.file_path_2 }}
+        run: echo '${{ secrets.FILE_CONTENT_2 }}' > ${{ inputs.file_path_2 }}
+
+      - name: Check version files
+        id: check-ver
+        run: |
+          if [[ -f .tool-versions || -f mise.toml || -f .node-version || -f .python-version ]]; then
+            echo "exist-any-version=1" >> $GITHUB_OUTPUT
+          fi
+          if [[ -f .node-version ]] || \
+             ([[ -f .tool-versions ]] && grep -qE '^(node|nodejs)[[:space:]]' .tool-versions) || \
+             ([[ -f mise.toml ]] && grep -qE '^[[:space:]]*(node|nodejs)[[:space:]]*=' mise.toml); then
+            echo "exist-nodejs-version=1" >> $GITHUB_OUTPUT
+          fi
+      - if: ${{ !steps.check-ver.outputs.exist-nodejs-version }}
+        uses: actions/setup-node@v6.5.0
+        with:
+          check-latest: true
+          node-version: lts/*
+      - if: ${{ steps.check-ver.outputs.exist-any-version && runner.environment == 'self-hosted' }}
+        name: Setup isolated GPG home
+        run: |
+          GNUPGHOME="$(mktemp -d "$RUNNER_TEMP/gnupg.XXXXXX")"
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+      - if: ${{ steps.check-ver.outputs.exist-any-version }}
+        uses: jdx/mise-action@v4.2.0
+        with:
+          cache: ${{ toJSON(runner.environment != 'self-hosted') }}
+      - name: Show environment information
+        id: env-info
+        run: |
+          echo "WB_ENV: $WB_ENV"
+          echo "node: $(node -v)"
+          echo "npm: $(npm -v)"
+          if [[ -f bunfig.toml ]] && \
+             (([[ -f .tool-versions ]] && grep -qE '^bun[[:space:]]' .tool-versions) || \
+              ([[ -f mise.toml ]] && grep -qE '^[[:space:]]*bun[[:space:]]*=' mise.toml)); then
+            echo "bun: $(bun -v)"
+            echo "runner=bun" >> $GITHUB_OUTPUT
+          else
+            YARN=$(yarn -v); echo "yarn: $YARN"
+            if [[ "$YARN" == "1."* ]]; then
+              echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+            fi
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+          fi
+      - if: ${{ steps.env-info.outputs.yarn-dir }}
+        uses: actions/cache@v6.1.0
+        with:
+          path: ${{ steps.env-info.outputs.yarn-dir }}
+          # Don't use **/yarn.lock because it scans yarn.lock in node_modules
+          # c.f. https://github.com/AllanChain/blog/issues/98
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1-
+      - name: Install dependencies
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            # Because bun sometimes fails to install private repos (but, update is okay)
+            bun install
+          else
+            ${{ steps.env-info.outputs.runner }} install || true # To ignore postinstall errors
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
+
+      - name: Run "common/ci-setup" npm script if exists
+        run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
+
+      - name: Run script
+        run: ${{ steps.env-info.outputs.runner }} run ${{ inputs.command }} ${{ inputs.command_args && format('-- {0}', inputs.command_args) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && failure() }}
+        run: |
+          REPO_LINK="[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})"
+          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -X POST -H "Content-Type: application/json" \
+               --data "{
+                  \"username\": \"WillBooster Bot\",
+                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
+                  \"content\": \"${{inputs.failure_mention_on_discord}} $REPO_LINK の ${{ inputs.command }} (${{ inputs.environment }}) が[失敗]($WORKFLOW_URL)しました！！！\"
+               }" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - if: ${{ always() }}
+        name: Delete credential files
+        run: rm -f ${{ inputs.dot_env_path }} ${{ inputs.file_path_1 }} ${{ inputs.file_path_2 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,12 @@ jobs:
             git checkout -B ${{ github.head_ref || github.ref_name }} origin/${{ github.head_ref || github.ref_name }}
           fi
           git reset --hard origin/${{ github.head_ref || github.ref_name }}
+      # The secret is passed via env and written with printf so that quotes or backslashes in
+      # its value cannot break out of the shell command.
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.HAS_DOT_ENV == 'true' }}
-        run: echo '${{ secrets.DOT_ENV }}' > ${{ inputs.dot_env_path }}
+        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        env:
+          DOT_ENV: ${{ secrets.DOT_ENV }}
 
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Check version files
@@ -329,6 +333,11 @@ jobs:
           name: test-artifact
           path: ${{ inputs.artifact_path }}
 
+      # Delete only when the DOT_ENV secret was actually written: dot_env_path defaults to
+      # .env, which some private repos commit.
+      - if: ${{ always() && env.HAS_DOT_ENV == 'true' }}
+        name: Delete credential files
+        run: rm -f -- "${{ inputs.dot_env_path }}"
       - if: ${{ always() }}
         name: Clean up pyc files, docker and ports
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,10 @@ jobs:
       # The secret is passed via env and written with printf so that quotes or backslashes in
       # its value cannot break out of the shell command.
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.HAS_DOT_ENV == 'true' }}
-        run: printf '%s\n' "$DOT_ENV" > "${{ inputs.dot_env_path }}"
+        run: printf '%s\n' "$DOT_ENV" > "$DOT_ENV_PATH"
         env:
           DOT_ENV: ${{ secrets.DOT_ENV }}
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
 
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Check version files
@@ -333,11 +334,13 @@ jobs:
           name: test-artifact
           path: ${{ inputs.artifact_path }}
 
-      # Delete only when the DOT_ENV secret was actually written: dot_env_path defaults to
-      # .env, which some private repos commit.
-      - if: ${{ always() && env.HAS_DOT_ENV == 'true' }}
+      # Delete only when the DOT_ENV secret was actually written by this run: dot_env_path
+      # defaults to .env, which some private repos commit.
+      - if: ${{ always() && needs.pre.outputs.should_skip != 'true' && env.HAS_DOT_ENV == 'true' }}
         name: Delete credential files
-        run: rm -f -- "${{ inputs.dot_env_path }}"
+        run: rm -f -- "$DOT_ENV_PATH"
+        env:
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
       - if: ${{ always() }}
         name: Clean up pyc files, docker and ports
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,9 +269,14 @@ jobs:
             ${{ steps.env-info.outputs.runner }} run build
           fi
           : # Exclude the dotenv file when the DOT_ENV secret overwrote it: a secret written
-          : # over a tracked file must never be committed and pushed by this autofix.
+          : # over a tracked file must never be committed and pushed by this autofix. Also
+          : # unstage it in case a caller-defined script staged it (git add -A in ci-setup etc.),
+          : # since the pathspec exclusion below cannot remove an existing index entry.
           excludes=()
-          if [[ "$HAS_DOT_ENV" == "true" ]]; then excludes=(":(exclude)$DOT_ENV_PATH"); fi
+          if [[ "$HAS_DOT_ENV" == "true" ]]; then
+            excludes=(":(exclude)$DOT_ENV_PATH")
+            git restore --staged -- "$DOT_ENV_PATH" 2> /dev/null || true
+          fi
           if [[ -n "$(git status --porcelain -- . "${excludes[@]}")" ]]; then
             git status
             git diff -- . "${excludes[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,11 +268,13 @@ jobs:
           elif grep -q '"build":' package.json; then
             ${{ steps.env-info.outputs.runner }} run build
           fi
-          if git status | grep -q "Changes not staged for commit"; then
+          : # Exclude the dotenv file: when dot_env_path names a tracked file, the DOT_ENV
+          : # secret written over it must never be committed and pushed by this autofix.
+          if [[ -n "$(git status --porcelain -- . ":(exclude)$DOT_ENV_PATH")" ]]; then
             git status
-            git diff
+            git diff -- . ":(exclude)$DOT_ENV_PATH"
             if [[ "${{ github.event.repository.private }}" == "true" ]]; then
-              git add -A
+              git add -A -- . ":(exclude)$DOT_ENV_PATH"
               git commit -m "fix: apply changes of autofix workflow" --no-verify
               git push origin ${{ github.head_ref }} --no-verify
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,13 +268,15 @@ jobs:
           elif grep -q '"build":' package.json; then
             ${{ steps.env-info.outputs.runner }} run build
           fi
-          : # Exclude the dotenv file: when dot_env_path names a tracked file, the DOT_ENV
-          : # secret written over it must never be committed and pushed by this autofix.
-          if [[ -n "$(git status --porcelain -- . ":(exclude)$DOT_ENV_PATH")" ]]; then
+          : # Exclude the dotenv file when the DOT_ENV secret overwrote it: a secret written
+          : # over a tracked file must never be committed and pushed by this autofix.
+          excludes=()
+          if [[ "$HAS_DOT_ENV" == "true" ]]; then excludes=(":(exclude)$DOT_ENV_PATH"); fi
+          if [[ -n "$(git status --porcelain -- . "${excludes[@]}")" ]]; then
             git status
-            git diff -- . ":(exclude)$DOT_ENV_PATH"
+            git diff -- . "${excludes[@]}"
             if [[ "${{ github.event.repository.private }}" == "true" ]]; then
-              git add -A -- . ":(exclude)$DOT_ENV_PATH"
+              git add -A -- . "${excludes[@]}"
               git commit -m "fix: apply changes of autofix workflow" --no-verify
               git push origin ${{ github.head_ref }} --no-verify
             else
@@ -282,6 +284,8 @@ jobs:
               exit 1
             fi
           fi
+        env:
+          DOT_ENV_PATH: ${{ inputs.dot_env_path }}
       # Typecheck must be executed after `gen-code`
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run "typecheck" npm script if exists


### PR DESCRIPTION
## Summary

Adds `.github/workflows/run-script.yml`, a reusable workflow that runs an arbitrary package.json script with the repo's dotenv/secret files in place, and hardens the credential/notification handling of `deploy.yml` and `test.yml` along the way.

### run-script.yml (new)

- For scheduled maintenance jobs (e.g. `ai-game-builder`'s monthly R2 orphan cleanup), replacing per-repo checkout/setup/install boilerplate.
- Inputs mirror `deploy.yml` conventions plus `command` (required package.json script), `command_args` (whitespace-split, documented contract), `environment` (exported as `WB_ENV`), `timeout_minutes` (applied to the script step so the `always()` credential cleanup still runs on timeout).
- Fails closed on dependency-installation errors (no `install || true`; deploy/test keep their long-standing postinstall tolerance — tracked in #426).

### Hardening applied consistently to run-script.yml, deploy.yml, and test.yml

- All secrets and caller-controlled inputs (`DOT_ENV`, `FILE_CONTENT_*`, paths, `command`/`command_args`, Discord fields) are passed via step `env` and never interpolated into inline shell; files are written with `printf`.
- Credential files are written and deleted only when the corresponding secret was actually provided (a caller committing `.env` or a file at `file_path_*` can no longer have it blanked/deleted), and test.yml's skip path no longer deletes a stale dotenv.
- test.yml's autofix can no longer commit/push a `DOT_ENV` secret written over a tracked file: the dotenv is unstaged from the index and excluded (conditional pathspec) from the dirty check, diff, and `git add`.
- Discord payloads are built from `toJSON()` expressions inserted via `printf %s` — injection-safe, `--fail-with-body`, and independent of provisioned tools so failure notifications work even when an early failure precedes setup-node/mise.
- Firebase credentials go to a `mktemp` path under `RUNNER_TEMP` (job-unique across matrix jobs), Discord payloads to `$RUNNER_TEMP`, avoiding cross-job clobbering on shared self-hosted runners.

## Review

`/review-fix agy,claude,codex` ran for 8 rounds until "There is no concern."; all Antigravity/Claude/Codex findings were fixed in place (one pre-existing install-suppression issue deferred to #426 for coordinated rollout).

## Test plan

- `yarn verify` passes; all three workflows parse as valid YAML; the production-banner JSON round-trip was verified with `JSON.parse`.
- Exercised end-to-end by `WillBoosterLab/ai-game-builder`'s converted `cleanup-orphan-r2-objects.yml` and deploy workflows (follow-up PR #680).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
