### PR TITLE
fix: fetch tags in deploy.yml so WB_VERSION keeps reporting the release tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,10 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
+          # WB_VERSION below comes from `git describe --always --tags`; without tags it silently
+          # degrades to a bare commit sha, so a production deploy would no longer report its
+          # release version (e.g. via a /version endpoint or the Discord notification).
+          fetch-tags: true
       # Secrets are passed via env and written with printf so that quotes or backslashes in
       # their values cannot break out of the shell command.
       - if: ${{ env.HAS_DOT_ENV == 'true' }}


### PR DESCRIPTION
The deploy job computes `WB_VERSION=$(git describe --always --tags)`, but `actions/checkout` defaults to `fetch-depth: 1` and `fetch-tags: false`, so on a fresh workspace no tag refs exist and the value silently degrades to a bare commit sha. Apps that surface `WB_VERSION` (e.g. a `/version` endpoint) then stop reporting their release version. Fetching tags restores it; production deploys run on the tagged commit, so a shallow tag fetch is enough.