### PR TITLE
fix: stop masking install failures and resolve ci-setup hooks from the deploy target

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -68,6 +68,12 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -78,7 +84,10 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install || true # To ignore postinstall errors
+            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
+            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
+            ${{ steps.env-info.outputs.runner }} install ||
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -84,10 +84,14 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
-            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
-            ${{ steps.env-info.outputs.runner }} install ||
+            : # Retry the same install first: this is the only network-bound step without a retry, and
+            : # letting a transient failure reach the fallback would skip every lifecycle script.
+            ${{ steps.env-info.outputs.runner }} install || ${{ steps.env-info.outputs.runner }} install || {
+              : # Only a reproducible failure reaches here, which keeps postinstall failures tolerated
+              : # (consumers rely on it) while resolution, auth and lockfile errors still fail the job.
+              echo "::warning::Install failed twice; retrying without lifecycle scripts"
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,13 @@ on:
       version:
         required: false
         type: string
+      working_directory:
+        # Deploy target directory (e.g. packages/server for a monorepo Worker). The "common/ci-setup"
+        # and "deploy/ci-setup" hooks are looked up here first and in the repository root as a
+        # fallback, and the deploy command runs here. Dependencies are still installed in the root.
+        default: .
+        required: false
+        type: string
     secrets:
       DISCORD_WEBHOOK_URL:
         required: false
@@ -197,6 +204,9 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -251,7 +261,10 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install || true # To ignore postinstall errors
+            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
+            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
+            ${{ steps.env-info.outputs.runner }} install ||
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
@@ -267,8 +280,28 @@ jobs:
         env:
           GCP_SA_KEY_JSON_FOR_FIREBASE: ${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}
 
+      # A monorepo Worker declares its hooks in its own package.json next to its wrangler config, which
+      # a root-only lookup misses; the root stays the fallback for single-package repos.
+      - name: Prepare "ci-setup" hook runner
+        run: |
+          echo "PKG_RUNNER=$PKG_RUNNER" >> $GITHUB_ENV
+          echo "WORKING_DIRECTORY=$WORKING_DIRECTORY" >> $GITHUB_ENV
+          cat << 'EOF' > "$RUNNER_TEMP/run-ci-setup.sh"
+          set -euo pipefail
+          for dir in "$WORKING_DIRECTORY" .; do
+            if grep -q "\"$1\":" "$dir/package.json" 2> /dev/null; then
+              echo "Running \"$1\" in $dir"
+              cd "$dir" && exec $PKG_RUNNER run "$1"
+            fi
+          done
+          echo "Skipped \"$1\": not declared in $WORKING_DIRECTORY/package.json nor ./package.json"
+          EOF
+        env:
+          PKG_RUNNER: ${{ steps.env-info.outputs.runner }}
+          WORKING_DIRECTORY: ${{ inputs.working_directory }}
+
       - name: Run "common/ci-setup" npm script if exists
-        run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
+        run: bash "$RUNNER_TEMP/run-ci-setup.sh" common/ci-setup
 
       - name: Deploy
         uses: nick-fields/retry@dd56f1ca8ca991e2385c18ab6dd36ea7f9fdb55f
@@ -277,7 +310,8 @@ jobs:
           max_attempts: ${{ (env.HAS_FLY_API_TOKEN == 'true' || env.HAS_RAILWAY_API_TOKEN == 'true' || env.HAS_GCP_SA_KEY_JSON == 'true') && 20 || 1 }}
           command: |
             : # GCP_SA_KEY_JSON may be used in deploy/ci-setup
-            if [[ "$(cat package.json)" == *'"deploy/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run deploy/ci-setup; fi
+            bash "$RUNNER_TEMP/run-ci-setup.sh" deploy/ci-setup
+            cd "$WORKING_DIRECTORY"
             ${{ steps.env-info.outputs.runner }} run ${{ inputs.deploy_command || 'deploy' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,10 +269,14 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
-            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
-            ${{ steps.env-info.outputs.runner }} install ||
+            : # Retry the same install first: this is the only network-bound step without a retry, and
+            : # letting a transient failure reach the fallback would skip every lifecycle script.
+            ${{ steps.env-info.outputs.runner }} install || ${{ steps.env-info.outputs.runner }} install || {
+              : # Only a reproducible failure reaches here, which keeps postinstall failures tolerated
+              : # (consumers rely on it) while resolution, auth and lockfile errors still fail the job.
+              echo "::warning::Install failed twice; retrying without lifecycle scripts"
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,10 +307,15 @@ jobs:
           if [[ "$WORKING_DIRECTORY" != "." ]]; then dirs+=(.); fi
           for dir in "${dirs[@]}"; do
             : # Reading the parsed "scripts" object avoids both false negatives ("key" : "value" is
-            : # valid JSON) and false positives (the same key in a non-"scripts" object).
-            if node -e 'const f=`${process.argv[1]}/package.json`, fs=require("fs"); if (!fs.existsSync(f)) process.exit(1); const s=JSON.parse(fs.readFileSync(f, "utf8")).scripts; process.exit(typeof s?.[process.argv[2]] === "string" ? 0 : 1)' "$dir" "$1"; then
+            : # valid JSON) and false positives (the same key in a non-"scripts" object). A BOM is
+            : # stripped because Yarn accepts it while JSON.parse does not, and exit 2 keeps an
+            : # unparseable manifest fatal rather than silently reading as "hook not declared".
+            node -e 'const f=`${process.argv[1]}/package.json`, fs=require("fs"); if (!fs.existsSync(f)) process.exit(1); let s; try { s = JSON.parse(fs.readFileSync(f, "utf8").replace(/^\uFEFF/, "")).scripts } catch (e) { console.error(`::error::Cannot parse ${f}: ${e.message}`); process.exit(2) } process.exit(typeof s?.[process.argv[2]] === "string" ? 0 : 1)' "$dir" "$1" && rc=0 || rc=$?
+            if [[ $rc -eq 0 ]]; then
               echo "Running \"$1\" in $dir"
               cd "$dir" && exec $PKG_RUNNER run "$1"
+            elif [[ $rc -ne 1 ]]; then
+              exit $rc
             fi
           done
           echo "Skipped \"$1\": not declared in ${dirs[*]/%//package.json}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,12 +150,17 @@ jobs:
           fi
       - name: Check gcloud is required
         id: check-gcloud
+        # The deploy target may live outside packages/*, so probe it too; otherwise gcloud would not
+        # be installed or authenticated for a deploy that needs it.
         run: |
           if [[ $HAS_GCP_SA_KEY_JSON == "true" ]]; then
-            if [[ "$(cat package.json)" == *gcloud* || "$(cat packages/*/package.json)" == *gcloud* ]]; then
+            if [[ "$(cat package.json)" == *gcloud* || "$(cat packages/*/package.json)" == *gcloud* || \
+                  "$(cat "$WORKING_DIRECTORY/package.json" 2> /dev/null)" == *gcloud* ]]; then
               echo "require-gcloud=1" >> $GITHUB_OUTPUT
             fi
           fi
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working_directory }}
       - if: ${{ !steps.check-ver.outputs.exist-nodejs-version }}
         uses: actions/setup-node@v6.5.0
         with:
@@ -287,10 +292,11 @@ jobs:
       # a root-only lookup misses; the root stays the fallback for single-package repos.
       - name: Prepare "ci-setup" hook runner
         run: |
-          : # Fail fast: without this, a typo'd path would silently fall back to the root hook and
-          : # then deploy the root package, since the lookup cannot tell it from "not declared here".
-          if [[ ! -d "$WORKING_DIRECTORY" ]]; then
-            echo "::error::working_directory \"$WORKING_DIRECTORY\" does not exist"
+          : # Fail fast: a path that is not a package (a typo like "packages" for "packages/server")
+          : # would otherwise run the root hook and, because `yarn run` walks up to the nearest
+          : # package, deploy the root package instead — succeeding while deploying the wrong thing.
+          if [[ ! -f "$WORKING_DIRECTORY/package.json" ]]; then
+            echo "::error::working_directory \"$WORKING_DIRECTORY\" has no package.json"
             exit 1
           fi
           echo "PKG_RUNNER=$PKG_RUNNER" >> $GITHUB_ENV
@@ -302,7 +308,7 @@ jobs:
           for dir in "${dirs[@]}"; do
             : # Reading the parsed "scripts" object avoids both false negatives ("key" : "value" is
             : # valid JSON) and false positives (the same key in a non-"scripts" object).
-            if node -e 'const f=`${process.argv[1]}/package.json`, fs=require("fs"); if (!fs.existsSync(f)) process.exit(1); const s=JSON.parse(fs.readFileSync(f, "utf8")).scripts; process.exit(s?.[process.argv[2]] ? 0 : 1)' "$dir" "$1"; then
+            if node -e 'const f=`${process.argv[1]}/package.json`, fs=require("fs"); if (!fs.existsSync(f)) process.exit(1); const s=JSON.parse(fs.readFileSync(f, "utf8")).scripts; process.exit(typeof s?.[process.argv[2]] === "string" ? 0 : 1)' "$dir" "$1"; then
               echo "Running \"$1\" in $dir"
               cd "$dir" && exec $PKG_RUNNER run "$1"
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,6 +205,9 @@ jobs:
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
               echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
             else
               echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
@@ -284,17 +287,27 @@ jobs:
       # a root-only lookup misses; the root stays the fallback for single-package repos.
       - name: Prepare "ci-setup" hook runner
         run: |
+          : # Fail fast: without this, a typo'd path would silently fall back to the root hook and
+          : # then deploy the root package, since the lookup cannot tell it from "not declared here".
+          if [[ ! -d "$WORKING_DIRECTORY" ]]; then
+            echo "::error::working_directory \"$WORKING_DIRECTORY\" does not exist"
+            exit 1
+          fi
           echo "PKG_RUNNER=$PKG_RUNNER" >> $GITHUB_ENV
           echo "WORKING_DIRECTORY=$WORKING_DIRECTORY" >> $GITHUB_ENV
           cat << 'EOF' > "$RUNNER_TEMP/run-ci-setup.sh"
           set -euo pipefail
-          for dir in "$WORKING_DIRECTORY" .; do
-            if grep -q "\"$1\":" "$dir/package.json" 2> /dev/null; then
+          dirs=("$WORKING_DIRECTORY")
+          if [[ "$WORKING_DIRECTORY" != "." ]]; then dirs+=(.); fi
+          for dir in "${dirs[@]}"; do
+            : # Reading the parsed "scripts" object avoids both false negatives ("key" : "value" is
+            : # valid JSON) and false positives (the same key in a non-"scripts" object).
+            if node -e 'const f=`${process.argv[1]}/package.json`, fs=require("fs"); if (!fs.existsSync(f)) process.exit(1); const s=JSON.parse(fs.readFileSync(f, "utf8")).scripts; process.exit(s?.[process.argv[2]] ? 0 : 1)' "$dir" "$1"; then
               echo "Running \"$1\" in $dir"
               cd "$dir" && exec $PKG_RUNNER run "$1"
             fi
           done
-          echo "Skipped \"$1\": not declared in $WORKING_DIRECTORY/package.json nor ./package.json"
+          echo "Skipped \"$1\": not declared in ${dirs[*]/%//package.json}"
           EOF
         env:
           PKG_RUNNER: ${{ steps.env-info.outputs.runner }}
@@ -309,6 +322,9 @@ jobs:
           timeout_minutes: 60
           max_attempts: ${{ (env.HAS_FLY_API_TOKEN == 'true' || env.HAS_RAILWAY_API_TOKEN == 'true' || env.HAS_GCP_SA_KEY_JSON == 'true') && 20 || 1 }}
           command: |
+            : # The retry action runs this via `bash -c` without -e, so without this a failing
+            : # deploy/ci-setup or cd would fall through and deploy anyway, reporting success.
+            set -euo pipefail
             : # GCP_SA_KEY_JSON may be used in deploy/ci-setup
             bash "$RUNNER_TEMP/run-ci-setup.sh" deploy/ci-setup
             cd "$WORKING_DIRECTORY"

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -125,6 +125,12 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -139,7 +145,10 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install --no-immutable || true # To ignore postinstall errors
+            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
+            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable ||
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -145,10 +145,14 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             bun install
           else
-            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
-            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
-            ${{ steps.env-info.outputs.runner }} install --no-immutable ||
+            : # Retry the same install first: this is the only network-bound step without a retry, and
+            : # letting a transient failure reach the fallback would skip every lifecycle script.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable || ${{ steps.env-info.outputs.runner }} install --no-immutable || {
+              : # Only a reproducible failure reaches here, which keeps postinstall failures tolerated
+              : # (consumers rely on it) while resolution, auth and lockfile errors still fail the job.
+              echo "::warning::Install failed twice; retrying without lifecycle scripts"
               ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,12 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -120,7 +126,10 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install || true # To ignore postinstall errors
+            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
+            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
+            ${{ steps.env-info.outputs.runner }} install ||
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,14 @@ jobs:
             # Because bun sometimes fails to install private repos (but, update is okay)
             bun install
           else
-            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
-            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
-            ${{ steps.env-info.outputs.runner }} install ||
+            : # Retry the same install first: this is the only network-bound step without a retry, and
+            : # letting a transient failure reach the fallback would skip every lifecycle script.
+            ${{ steps.env-info.outputs.runner }} install || ${{ steps.env-info.outputs.runner }} install || {
+              : # Only a reproducible failure reaches here, which keeps postinstall failures tolerated
+              : # (consumers rely on it) while resolution, auth and lockfile errors still fail the job.
+              echo "::warning::Install failed twice; retrying without lifecycle scripts"
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -159,7 +159,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
       - name: Install dependencies
-        # Unlike deploy.yml/test.yml, install failures are NOT suppressed here: a maintenance
+        # Unlike deploy.yml/test.yml, even postinstall failures are NOT tolerated here: a maintenance
         # script run against a half-installed dependency graph could silently misbehave.
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -159,7 +159,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
       - name: Install dependencies
-        # Unlike deploy.yml/test.yml, even postinstall failures are NOT tolerated here: a maintenance
+        # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance
         # script run against a half-installed dependency graph could silently misbehave.
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,9 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -235,7 +238,10 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             bun install
           else
-            ${{ steps.env-info.outputs.runner }} install --no-immutable || true # To ignore postinstall errors
+            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
+            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable ||
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,10 +241,14 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             bun install
           else
-            : # Retrying without lifecycle scripts keeps postinstall failures tolerated (consumers rely
-            : # on it) while resolution, authentication, network and lockfile errors still fail the job.
-            ${{ steps.env-info.outputs.runner }} install --no-immutable ||
+            : # Retry the same install first: this is the only network-bound step without a retry, and
+            : # letting a transient failure reach the fallback would skip every lifecycle script.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable || ${{ steps.env-info.outputs.runner }} install --no-immutable || {
+              : # Only a reproducible failure reaches here, which keeps postinstall failures tolerated
+              : # (consumers rely on it) while resolution, auth and lockfile errors still fail the job.
+              echo "::warning::Install failed twice; retrying without lifecycle scripts"
               ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,6 +192,9 @@ jobs:
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
               echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
             else
               echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi


### PR DESCRIPTION
Close #426
Close #428

## Customer Summary

- A deploy whose `deploy/ci-setup` check fails now stops instead of deploying anyway and reporting success. That check exists to catch things like half-configured secrets before they reach production, so it was failing open on exactly the case it guards.
- Monorepo Workers can declare `common/ci-setup` / `deploy/ci-setup` in their own package (next to their wrangler config) and have CI actually run them. Previously those hooks were silently skipped on CI and ran only locally — the inverse of their intended guarantee.
- CI jobs no longer pass silently on a broken dependency install. A genuine failure (unreachable registry, bad credentials, unresolvable package) now fails the job instead of letting later steps run against a half-installed dependency graph. Installs that fail only in a postinstall script are still tolerated, as before, and now say so in the job summary.
- No action needed for existing callers: the new `working_directory` input defaults to the repository root, so current behavior is unchanged. Projects that previously worked around the hook bug with per-project delegation boilerplate (WillBooster/agentic-workflows#347) can drop it.

## Technical Summary

- Replaced `install || true` with `install || install || { warn; install <skip-scripts-option>; }` in `deploy.yml`, `test.yml`, `autofix.yml`, `release.yml` and `gen-pr.yml`. The middle attempt keeps a transient failure from reaching the fallback and silently skipping every lifecycle script; only a reproducible failure gets there.
- `skip-scripts-option` is resolved per Yarn generation in the existing `env-info` step: `--ignore-scripts` (Yarn 1), `--skip-builds` (Yarn 2), `--mode=skip-build` (Yarn 3+).
- Added a `working_directory` input to `deploy.yml` (default `.`). Hooks resolve against the deploy target first and the repository root as a fallback, logging which `package.json` was used or which were checked on a skip. The deploy command runs there; dependencies still install at the root so workspace installs keep working.
- The hook lookup reads the parsed `scripts` object via `node -e` rather than grepping the serialization, strips a leading UTF-8 BOM (Yarn accepts one, `JSON.parse` does not), and treats an unparseable manifest as fatal rather than as "hook not declared".
- Guards added: `set -euo pipefail` on the Deploy command (the retry action runs it via `bash -c` with no `-e`), a `package.json` existence check on `working_directory`, and gcloud detection that follows the new input.

## Why

- `install || true` suppressed resolution, authentication, network and lockfile failures, not just the postinstall errors its comment claimed (#426). The tolerance is long-standing, so the issue asked for a lifecycle-skipping fallback rather than a bare removal — that keeps the postinstall path working while closing the rest.
- `deploy.yml` grepped only the root `package.json` for the hooks (#428). Since `wb deploy` deliberately skips `deploy/ci-setup` on CI and defers to this workflow, a monorepo Worker's hook ran only locally.
- The three extra workflows carried the identical masking. Fixing them here avoids leaving the bug class half-addressed and keeps all six install steps consistent.

## Testing

- `yarn verify` — passes.
- Reviewed via `/review-fix` across five rounds (Codex, Claude Code, Antigravity); the final round returned "There is no concern."
- Behavior was verified against real package managers and the pinned action's own source, not just reasoned about. The install chain, hook helper and Deploy command were extracted from the committed YAML so the tested text is the shipped text:
  - Yarn 1.22.22, 2.4.3 and 4.17.1: persistent postinstall failure → tolerated (exit 0) with a warning; transient failure then success → absorbed, lifecycle scripts run; persistent unresolvable dependency / ECONNREFUSED → non-zero, job fails (previously masked).
  - Yarn 2.4.3 rejects `--mode=skip-build` (`Invalid option name`) and accepts `--skip-builds`; Yarn 1 ignores the unknown `--no-immutable` rather than erroring.
  - Hook resolution: in worker package → runs there; only at root → falls back; absent → named skip, exit 0; fails → deploy does not run, step exits non-zero.
  - `working_directory=packages` (exists, no `package.json`) → fails fast; verified that `cd packages && yarn run deploy` otherwise runs the *root* script and exits 0.
  - `"key" : ""`, a same-named key in a non-`scripts` object, and a BOM'd manifest → found / ignored / found; unparseable manifest → fails loudly.
  - Replayed `spawn(command, {shell: 'bash'})` exactly as `nick-fields/retry@dd56f1ca` does, confirming a failing hook previously left the deploy running with exit 0, and aborts after the fix.

## Notes

- This repo runs no CI on workflow changes (they are exercised by consumer repos), which is why the verification above is local and against real Yarn binaries.
- Behavior change worth flagging on rollout: callers whose `deploy/ci-setup` currently fails silently will start seeing failed deploys. That is the intent of #428, but it may surface latent breakage on the first run.
- An earlier revision of this description claimed a failing hook already aborted the deploy. That was wrong and is fixed here; the claim is retained above rather than dropped so the record is accurate.
