### PR TITLE
fix: send deleted lockfiles to pkg-preflight and extend request timeout

### DIFF
--- a/.github/scripts/create-pkg-preflight-request.cjs
+++ b/.github/scripts/create-pkg-preflight-request.cjs
@@ -36,9 +36,11 @@ fs.mkdirSync(requestDir, { recursive: true });
 for (let index = 0; index < changedFiles.length; index += MaxFilesPerRequest) {
   const files = changedFiles.slice(index, index + MaxFilesPerRequest).map((file) => ({
     path: file.path,
-    // Keep this undefined for new files because the API schema accepts an optional string, not null.
+    // Keep these undefined for new/deleted files because the API schema accepts an optional string, not null.
     before: readBaseFile(file.beforePath ?? file.path),
-    after: fs.readFileSync(file.path, 'utf8'),
+    // Deleted lockfiles have no `after` content; pkg-preflight uses their `before` packages as the
+    // baseline for replacement lockfiles (e.g. a yarn-to-bun migration).
+    after: file.deleted ? undefined : fs.readFileSync(file.path, 'utf8'),
   }));
   fs.writeFileSync(path.join(requestDir, `${index / MaxFilesPerRequest}.json`), JSON.stringify({ json: { files } }));
 }
@@ -116,10 +118,17 @@ function listPullRequestChangedFiles({ pullRequestNumber, repository, token }) {
     totalFetched += files.length;
     changedFiles.push(
       ...files
-        .filter((file) => file.status === 'added' || file.status === 'modified' || file.status === 'renamed')
+        .filter(
+          (file) =>
+            file.status === 'added' ||
+            file.status === 'modified' ||
+            file.status === 'renamed' ||
+            file.status === 'removed'
+        )
         .map((file) => ({
           path: file.filename,
           beforePath: file.status === 'renamed' ? file.previous_filename : undefined,
+          deleted: file.status === 'removed',
         }))
         .filter((file) => file.path)
     );
@@ -131,7 +140,7 @@ function listPullRequestChangedFiles({ pullRequestNumber, repository, token }) {
 }
 
 function listGitChangedFiles() {
-  const records = execFileSync('git', ['diff', '-z', '--name-status', '--diff-filter=AMR', 'FETCH_HEAD'], {
+  const records = execFileSync('git', ['diff', '-z', '--name-status', '--diff-filter=AMRD', 'FETCH_HEAD'], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
   })
@@ -161,7 +170,7 @@ function listGitChangedFiles() {
     index += 1;
 
     if (filePath) {
-      changedFiles.push({ path: filePath });
+      changedFiles.push({ path: filePath, deleted: status.startsWith('D') });
     }
   }
 
@@ -191,8 +200,11 @@ function postRequest(requestPath) {
     'curl',
     [
       '--fail-with-body',
+      // Railway's proxy allows roughly 300 seconds per request; stay just below it so large
+      // uncached lockfile diffs can finish while retries make incremental progress via the
+      // service's persistent scan cache.
       '--max-time',
-      '120',
+      '280',
       '--retry',
       String(PkgPreflightRetryAttempts),
       '--retry-delay',


### PR DESCRIPTION
## Problem

`create-pkg-preflight-request.cjs` filtered changed files with `--diff-filter=AMR` / PR statuses `added|modified|renamed`, dropping deleted lockfiles. For a package-manager migration (e.g. WillBooster/shared#958: `yarn.lock` removed, `bun.lock` added), pkg-preflight received only the brand-new `bun.lock` with no baseline, treated ~1700 packages as new, and timed out (CI curl `--max-time 120`, Railway proxy 502 after ~300s).

## Fix

- Include removed lockfiles in the request as before-only entries (`after` omitted). WillBooster/pkg-preflight#46 accepts these and uses them as the baseline package set, so only packages whose resolved versions actually changed are analyzed.
- Raise curl `--max-time` from 120s to 280s (just below Railway's ~300s proxy limit) so large uncached diffs can finish; retries still make incremental progress via the service's persistent scan cache.

Depends on WillBooster/pkg-preflight#46 being deployed (older service versions reject `after`-less files with 400; note the service previously also could not parse Yarn Berry lockfiles, so `before` content was effectively unused for such repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
