### PR TITLE
feat!: replace NPM_TOKEN with VERDACCIO_TOKEN and auto-generate a workspace .npmrc

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,7 +12,8 @@ on:
         required: false
       GH_PKG_READ_TOKEN:
         required: false
-      NPM_TOKEN:
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
 
 concurrency:
@@ -26,9 +27,9 @@ jobs:
     env:
       # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
       # To trigger other workflows when running 'git push'
       - name: Checkout code with git
@@ -89,6 +90,15 @@ jobs:
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
 
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ on:
       GH_PKG_READ_TOKEN:
         required: false
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
     env:
       # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
@@ -90,15 +90,25 @@ jobs:
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
 
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -125,7 +125,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - name: Install dependencies
         run: |

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -101,17 +101,25 @@ jobs:
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -94,21 +94,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
@@ -154,3 +164,20 @@ jobs:
         env:
           HUSKY: 0
           LEFTHOOK: 0
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -293,17 +293,25 @@ jobs:
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,15 @@ jobs:
     steps:
       - if: ${{ runner.environment == 'self-hosted' }}
         run: if [[ ! $(docker ps) ]]; then sudo reboot; fi
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
@@ -317,7 +326,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -286,21 +286,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
@@ -465,6 +475,23 @@ jobs:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}
           FILE_PATH_2: ${{ inputs.file_path_2 }}
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi
       - if: ${{ always() }}
         name: Clean up pyc files and docker
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,9 +91,10 @@ on:
         required: false
       GH_PKG_READ_TOKEN:
         required: false
-      NPM_TOKEN:
-        required: false
       RAILWAY_API_TOKEN:
+        required: false
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
 
 jobs:
@@ -115,9 +116,9 @@ jobs:
       HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
       HAS_GCP_SA_KEY_JSON_FOR_FIREBASE: ${{ !!secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}
       HAS_RAILWAY_API_TOKEN: ${{ !!secrets.RAILWAY_API_TOKEN }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
       - if: ${{ runner.environment == 'self-hosted' }}
@@ -281,6 +282,15 @@ jobs:
       - if: ${{ steps.check-gcloud.outputs.require-gcloud }}
         name: Configure docker to use gcloud
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ on:
       RAILWAY_API_TOKEN:
         required: false
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
 
 jobs:
@@ -116,7 +116,7 @@ jobs:
       HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
       HAS_GCP_SA_KEY_JSON_FOR_FIREBASE: ${{ !!secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}
       HAS_RAILWAY_API_TOKEN: ${{ !!secrets.RAILWAY_API_TOKEN }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
@@ -282,15 +282,25 @@ jobs:
       - if: ${{ steps.check-gcloud.outputs.require-gcloud }}
         name: Configure docker to use gcloud
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -160,21 +160,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
@@ -262,3 +272,20 @@ jobs:
           fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -87,6 +87,15 @@ jobs:
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - uses: actions/checkout@v7.0.0
         with:
           token: ${{ secrets.GH_TOKEN }}
@@ -191,7 +200,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - name: Install dependencies
         run: |
@@ -235,7 +249,12 @@ jobs:
           if git ls-files --error-unmatch -- "$DOT_ENV_PATH" > /dev/null 2>&1; then
             git update-index --skip-worktree -- "$DOT_ENV_PATH"
           else
-            grep -qxF -- "$DOT_ENV_PATH" .git/info/exclude 2> /dev/null || printf '%s\n' "$DOT_ENV_PATH" >> .git/info/exclude
+            if ! grep -qxF -- "$DOT_ENV_PATH" .git/info/exclude 2> /dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and let gen-pr's `git add -A` stage the dotenv file.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              printf '%s\n' "$DOT_ENV_PATH" >> .git/info/exclude
+            fi
           fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -11,6 +11,9 @@ on:
       github_hosted_runner:
         required: false
         type: boolean
+      runs_on:
+        required: false
+        type: string
       dot_env_path:
         default: .env
         required: false
@@ -290,12 +293,18 @@ jobs:
       - if: ${{ always() && env.HAS_DOT_ENV == 'true' }}
         name: Delete credential files
         run: |
-          rm -f -- "$DOT_ENV_PATH"
-          git update-index --no-skip-worktree -- "$DOT_ENV_PATH" 2> /dev/null || true
-          if [[ -f .git/info/exclude ]]; then
-            : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
-            grep -vxF -- "$DOT_ENV_PATH" .git/info/exclude > .git/info/exclude.tmp || true
-            mv .git/info/exclude.tmp .git/info/exclude
+          : # Restore a committed dotenv template instead of deleting it, which would leave the
+          : # persistent workspace dirty with a deleted tracked file.
+          if git ls-files --error-unmatch -- "$DOT_ENV_PATH" > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- "$DOT_ENV_PATH" 2> /dev/null || true
+            git checkout -- "$DOT_ENV_PATH" 2> /dev/null || true
+          else
+            rm -f -- "$DOT_ENV_PATH"
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- "$DOT_ENV_PATH" .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
           fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -70,7 +70,8 @@ on:
         required: false
       GH_PKG_READ_TOKEN:
         required: false
-      NPM_TOKEN:
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
 
 jobs:
@@ -82,9 +83,9 @@ jobs:
       # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -155,6 +156,15 @@ jobs:
             echo "poetry: $POETRY"
             poetry config virtualenvs.in-project true
           fi
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -71,7 +71,7 @@ on:
       GH_PKG_READ_TOKEN:
         required: false
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
 
 jobs:
@@ -83,7 +83,7 @@ jobs:
       # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
@@ -156,15 +156,25 @@ jobs:
             echo "poetry: $POETRY"
             poetry config virtualenvs.in-project true
           fi
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -167,17 +167,25 @@ jobs:
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,15 @@ jobs:
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - uses: actions/checkout@v7.0.0
       # fnox exits 0 and silently omits age-encrypted secrets when FNOX_AGE_KEY is missing or
       # wrong, so fail fast instead of releasing without secrets.
@@ -177,7 +186,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,17 +153,25 @@ jobs:
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ on:
         required: false
       GH_TOKEN:
         required: true
-      NPM_TOKEN:
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
       GH_PACKAGES_TOKEN:
         required: false
@@ -58,9 +59,9 @@ jobs:
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v7.0.0
@@ -141,6 +142,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
 
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
@@ -174,7 +184,8 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
+          NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
           HUSKY: 0
           LEFTHOOK: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ on:
       GH_TOKEN:
         required: true
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
       GH_PACKAGES_TOKEN:
         required: false
@@ -59,7 +59,7 @@ jobs:
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
@@ -142,15 +142,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
 
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,21 +146,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
@@ -233,3 +243,20 @@ jobs:
         run: rm -f -- "$DOT_ENV_PATH"
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -180,17 +180,25 @@ jobs:
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -95,6 +95,15 @@ jobs:
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
@@ -204,7 +213,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - name: Install dependencies
         # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -75,7 +75,7 @@ on:
       GH_PKG_READ_TOKEN:
         required: false
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
 
 jobs:
@@ -90,7 +90,7 @@ jobs:
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_FILE_CONTENT_1: ${{ !!secrets.FILE_CONTENT_1 }}
       HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
@@ -169,15 +169,25 @@ jobs:
           key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - name: Install dependencies
         # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance
         # script run against a half-installed dependency graph could silently misbehave.

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -173,21 +173,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - name: Install dependencies
         # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance
         # script run against a half-installed dependency graph could silently misbehave.
@@ -243,3 +253,20 @@ jobs:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
           FILE_PATH_1: ${{ inputs.file_path_1 }}
           FILE_PATH_2: ${{ inputs.file_path_2 }}
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -74,7 +74,8 @@ on:
         required: false
       GH_PKG_READ_TOKEN:
         required: false
-      NPM_TOKEN:
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
 
 jobs:
@@ -89,9 +90,9 @@ jobs:
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_FILE_CONTENT_1: ${{ !!secrets.FILE_CONTENT_1 }}
       HAS_FILE_CONTENT_2: ${{ !!secrets.FILE_CONTENT_2 }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v7.0.0
@@ -168,6 +169,15 @@ jobs:
           key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-v1-
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - name: Install dependencies
         # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance
         # script run against a half-installed dependency graph could silently misbehave.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,8 @@ on:
         required: false
       GH_TOKEN:
         required: true
-      NPM_TOKEN:
+      VERDACCIO_TOKEN:
+        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
         required: false
 jobs:
   pre:
@@ -110,9 +111,9 @@ jobs:
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_TEST_COMMAND: ${{ !!inputs.custom_test_command }}
-      # Consumers' .npmrc references NPM_TOKEN to authenticate against the private Verdaccio
+      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment || 'test' }}
     strategy:
       matrix:
@@ -243,6 +244,15 @@ jobs:
           WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
           WORKFLOW_SHA: ${{ job.workflow_sha }}
 
+      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
+      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && env.VERDACCIO_TOKEN != '' }}
+        name: Generate ~/.npmrc for the private Verdaccio registry
+        run: |
+          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
+            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
+          } >> ~/.npmrc
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |
@@ -359,7 +369,8 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
+          NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' && inputs.artifact_path }}
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,21 +248,31 @@ jobs:
       # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
       # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
       # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
-      # authoritatively so stale entries never win over the current token, and the file is
-      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
-      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
+      # authoritatively so stale entries never win over the current token, and the file is hidden
+      # from git (a root-scoped exclude entry, or skip-worktree when the consumer tracks .npmrc)
+      # so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc; Berry consumers
+      # must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
           touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+          : # Some grep implementations do not add the final newline missing from the last line.
+          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
           {
-            cat .npmrc.tmp
+            cat "$NPMRC_TMP"
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
           } > .npmrc
-          rm .npmrc.tmp
-          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
+          rm "$NPMRC_TMP"
+          : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
+          : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --skip-worktree -- .npmrc
+          else
+            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+          fi
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |
@@ -394,6 +404,23 @@ jobs:
         run: rm -f -- "$DOT_ENV_PATH"
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+      # Revert the generate step: remove the file when this run created it, or restore the
+      # committed content and clear the skip-worktree bit when the consumer tracks .npmrc; the
+      # `.git` mutations otherwise outlive the job on persistent self-hosted workspaces.
+      - if: ${{ always() && needs.pre.outputs.should_skip != 'true' && env.VERDACCIO_TOKEN != '' }}
+        name: Clean up the generated .npmrc
+        run: |
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          else
+            rm -f .npmrc
+            if [[ -f .git/info/exclude ]]; then
+              : # `grep -vx` exits 1 when every line matches, so tolerate it to keep `bash -e` green.
+              grep -vxF -- '/.npmrc' .git/info/exclude > .git/info/exclude.tmp || true
+              mv .git/info/exclude.tmp .git/info/exclude
+            fi
+          fi
       - if: ${{ always() }}
         name: Clean up pyc files, docker and ports
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,17 +255,25 @@ jobs:
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.VERDACCIO_TOKEN != '' }}
         name: Generate .npmrc for the private Verdaccio registry
         run: |
+          : # Recover state a crashed previous run may have left behind (the always() cleanup
+          : # cannot run when the runner dies): clear a stale skip-worktree bit and restore the
+          : # committed content before regenerating.
+          if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+            git update-index --no-skip-worktree -- .npmrc 2> /dev/null || true
+            git checkout -- .npmrc 2> /dev/null || true
+          fi
           NPMRC_TMP=$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")
-          touch .npmrc
-          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
-          : # Some grep implementations do not add the final newline missing from the last line.
-          if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
-          {
-            cat "$NPMRC_TMP"
-            echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
-            echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } > .npmrc
-          rm "$NPMRC_TMP"
+          if [[ -e .npmrc ]]; then
+            grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > "$NPMRC_TMP" || true
+            : # Some grep implementations do not add the final newline missing from the last line.
+            if [[ -s "$NPMRC_TMP" && -n "$(tail -c1 "$NPMRC_TMP")" ]]; then echo >> "$NPMRC_TMP"; fi
+          fi
+          echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/' >> "$NPMRC_TMP"
+          echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}' >> "$NPMRC_TMP"
+          : # Replace .npmrc with mv instead of writing into it, so a consumer-committed symlink
+          : # cannot redirect the managed lines into its target (e.g. a persistent home npmrc).
+          rm -f .npmrc
+          mv "$NPMRC_TMP" .npmrc
           : # Ignore rules never hide tracked files, so hide a committed .npmrc from the
           : # commit-and-push workflows with skip-worktree (same pattern as gen-pr's dotenv hide).
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ on:
       GH_TOKEN:
         required: true
       VERDACCIO_TOKEN:
-        description: auth token for the private Verdaccio registry (used to generate ~/.npmrc)
+        description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
 jobs:
   pre:
@@ -111,7 +111,7 @@ jobs:
       FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_TEST_COMMAND: ${{ !!inputs.custom_test_command }}
-      # Referenced by the generated ~/.npmrc to authenticate against the private Verdaccio
+      # Referenced by the generated .npmrc to authenticate against the private Verdaccio
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment || 'test' }}
@@ -244,15 +244,25 @@ jobs:
           WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
           WORKFLOW_SHA: ${{ job.workflow_sha }}
 
-      # ${VERDACCIO_TOKEN} is written literally; package managers expand it from the environment
-      # at install time, so no plaintext token lands on disk (self-hosted runners keep $HOME).
+      # ${VERDACCIO_TOKEN} is written literally; npm/bun/yarn1 expand it from the environment at
+      # install time, so no plaintext token lands on disk. The file goes into the workspace, NOT
+      # ~/.npmrc: a persistent ~/.npmrc would crash npm/yarn1 in any other job on the same
+      # self-hosted runner that leaves VERDACCIO_TOKEN undefined. The managed lines are rewritten
+      # authoritatively so stale entries never win over the current token, and the file is
+      # git-excluded so commit-and-push workflows cannot commit it. Yarn Berry ignores .npmrc;
+      # Berry consumers must reference ${VERDACCIO_TOKEN} from their committed .yarnrc.yml instead.
       - if: ${{ needs.pre.outputs.should_skip != 'true' && env.VERDACCIO_TOKEN != '' }}
-        name: Generate ~/.npmrc for the private Verdaccio registry
+        name: Generate .npmrc for the private Verdaccio registry
         run: |
-          grep -qsF '@willbooster-private:registry' ~/.npmrc || {
+          touch .npmrc
+          grep -vE '^(@willbooster-private:registry|//verdaccio-production-e389\.up\.railway\.app/:_authToken)' .npmrc > .npmrc.tmp || true
+          {
+            cat .npmrc.tmp
             echo '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/'
             echo '//verdaccio-production-e389.up.railway.app/:_authToken=${VERDACCIO_TOKEN}'
-          } >> ~/.npmrc
+          } > .npmrc
+          rm .npmrc.tmp
+          grep -qxF '.npmrc' .git/info/exclude 2>/dev/null || echo '.npmrc' >> .git/info/exclude
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,16 @@ jobs:
     outputs:
       json: ${{ steps.detect-node-version-matrix.outputs.json }}
     steps:
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' }}
+        name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         uses: actions/checkout@v7.0.0
       # We need Node.js only if no version is declared in mise-managed files and no .node-version exists.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,15 @@ jobs:
         with:
           cancel_others: true
           paths_ignore: ${{ inputs.paths_ignore }}
+      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
+      # survive every reset/clean and make checkout fail once the consumer deletes the committed
+      # file, permanently wedging a persistent workspace — clear them before checkout.
+      - name: Clear stale skip-worktree bits left by a crashed previous run
+        run: |
+          if [[ -d .git ]]; then
+            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+            git checkout -- . 2> /dev/null || true
+          fi
       - if: ${{ needs.pre.outputs.should_skip != 'true' && !github.event.repository.private }}
         uses: actions/checkout@v7.0.0
       - if: ${{ needs.pre.outputs.should_skip != 'true' && github.event.repository.private }}
@@ -279,7 +288,12 @@ jobs:
           if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
             git update-index --skip-worktree -- .npmrc
           else
-            grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null || echo '/.npmrc' >> .git/info/exclude
+            if ! grep -qxF '/.npmrc' .git/info/exclude 2>/dev/null; then
+              : # A persistent exclude file may end without a newline; a direct append would
+              : # merge into its last rule and leave the generated file unhidden.
+              if [[ -s .git/info/exclude && -n "$(tail -c1 .git/info/exclude)" ]]; then echo >> .git/info/exclude; fi
+              echo '/.npmrc' >> .git/info/exclude
+            fi
           fi
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Install dependencies


### PR DESCRIPTION
## Customer Summary

- Repositories no longer need to commit an `.npmrc` file for WillBooster's private package registry (Verdaccio). On developer machines the registry settings live in each developer's personal `~/.npmrc` (from the Bitwarden item `~/.npmrc (verdaccio)`); on CI the shared workflows now set everything up automatically.
- To enable private packages on CI, a repository only passes the new `VERDACCIO_TOKEN` secret to the shared workflows. The old `NPM_TOKEN` secret no longer works and must be renamed.

## Technical Summary

- All six dependency-installing reusable workflows (`test.yml`, `deploy.yml`, `release.yml`, `run-script.yml`, `gen-pr.yml`, `autofix.yml`) accept an optional `VERDACCIO_TOKEN` secret, expose it as a job-level env var, and generate a workspace `.npmrc` before installation:
  - `@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/` plus an `_authToken=${VERDACCIO_TOKEN}` line; the `${...}` is written literally and expanded by npm/bun/yarn1 from the environment, so no plaintext token lands on disk.
  - The step is symlink-safe (content is built in `$RUNNER_TEMP` and `mv`ed over `.npmrc`), rewrites its managed lines authoritatively (stale entries never win), and guards exclude-file appends against files missing a final newline.
  - The file is hidden from git via a root-scoped `/.npmrc` entry in `.git/info/exclude`, or `git update-index --skip-worktree` when the consumer tracks `.npmrc`, so commit-and-push workflows (`autofix`, `gen-pr`, private-repo `test`) can never commit it.
  - An `always()` cleanup step reverts the file and all `.git` mutations, and a pre-checkout step clears stale skip-worktree bits left by crashed runs so a persistent self-hosted workspace can never get wedged (autofix wipes `.git` every run and needs neither).
- The semantic-release steps in `release.yml`/`test.yml` keep the `NPM_TOKEN` env var name (required by semantic-release's npm plugin), fed from `secrets.VERDACCIO_TOKEN`.
- Drive-by fixes in `gen-pr.yml`: declare the previously missing `runs_on` input its `runs-on` expression references; restore a tracked dotenv template via `git checkout` in cleanup instead of deleting it; and guard its dotenv exclude append against newline-less exclude files.

## Why

- Consumer repositories are dropping committed `.npmrc` files (registry auth is personal `~/.npmrc` configuration managed via Bitwarden), so CI needs to provision the registry configuration itself instead of relying on a committed file referencing `${NPM_TOKEN}`.
- A workspace `.npmrc` (not `~/.npmrc`) is used because npm/yarn1 crash on any npmrc referencing an undefined env var, which would break unrelated jobs sharing a self-hosted runner's home directory.

## Testing

- `bun verify` (type check + lint) passes; `actionlint` reports no new issues on the six workflows.
- The generation/cleanup shell logic was exercised locally against: no existing `.npmrc`, files without trailing newlines, stale managed lines, tracked `.npmrc`, tracked symlinked `.npmrc`, nested package-level `.npmrc`, crash recovery (cleanup skipped), and idempotent reruns.
- Seven rounds of multi-agent review (Codex, Claude Code, Antigravity) ended with no remaining concerns.

## Notes

- BREAKING CHANGE: the `NPM_TOKEN` secret is removed without fallback. Callers passing `NPM_TOKEN:` under `secrets:` fail validation until renamed to `VERDACCIO_TOKEN`; committed `.npmrc` files referencing `${NPM_TOKEN}` must be deleted; consumer scripts reading `$NPM_TOKEN` must switch to `$VERDACCIO_TOKEN`; Yarn Berry consumers must reference `${VERDACCIO_TOKEN}` from `.yarnrc.yml` (Berry ignores `.npmrc`).
- Docker builds do not see the workspace `.npmrc` protections: Dockerfiles must not `COPY` it, and image builds needing private packages should pass auth explicitly (e.g. a BuildKit secret).
- Shell-quoting hardening of `github.head_ref` interpolation (pre-existing) is tracked in #433.
