### PR TITLE
fix: fetch tags before reading the pre-release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
     concurrency:
       group: release-${{ github.repository }}
       cancel-in-progress: false
+      # The default queue (`single`) cancels an already-pending run when another one queues,
+      # silently dropping a release; keep every queued release.
+      queue: max
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || fromJSON('["self-hosted", "medium"]') }}
     env:
       FORCE_COLOR: 3
@@ -267,27 +270,38 @@ jobs:
         # which prefers annotated tags and can hide semantic-release's lightweight tag
         # behind an annotated one on the same commit) identifies the created tag. Tag names
         # may contain shell metacharacters, so they reach later scripts only via env.
+        # A new tag counts as this run's when its commit is GITHUB_SHA or a descendant of it
+        # (release scripts like `npm version` tag a commit they create on top of GITHUB_SHA);
+        # pre-existing tags point at ancestors and never match. Multiple tags are kept
+        # space-joined (refnames cannot contain spaces): multi-semantic-release tags every
+        # workspace package on the same commit. The qualified ref + --end-of-options keeps
+        # tag names starting with '-' from being parsed as options.
         run: |
           git fetch --tags --force || true
           git tag --list | sort > "$RUNNER_TEMP/tags-after-release.txt"
-          NEW_TAG=''
+          NEW_TAGS=''
           while IFS= read -r tag; do
-            if [[ "$(git rev-parse "$tag^{commit}" 2>/dev/null)" == "$GITHUB_SHA" ]]; then
-              NEW_TAG=$tag
-              break
+            TAG_COMMIT=$(git rev-parse --verify --end-of-options "refs/tags/$tag^{commit}" 2>/dev/null) || continue
+            if git merge-base --is-ancestor "$GITHUB_SHA" "$TAG_COMMIT" 2>/dev/null; then
+              NEW_TAGS="${NEW_TAGS:+$NEW_TAGS }$tag"
             fi
           done < <(comm -13 "$RUNNER_TEMP/tags-before-release.txt" "$RUNNER_TEMP/tags-after-release.txt")
-          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
-          if [[ -n "$NEW_TAG" ]]; then
+          echo "tags=$NEW_TAGS" >> "$GITHUB_OUTPUT"
+          echo "tag=${NEW_TAGS%% *}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$NEW_TAGS" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
       - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
-        run: gh workflow run "$DEPLOY_WORKFLOW" --ref "$NEW_TAG"
+        # Word splitting on $NEW_TAGS is intended: refnames cannot contain spaces.
+        run: |
+          for tag in $NEW_TAGS; do
+            gh workflow run "$DEPLOY_WORKFLOW" --ref "$tag"
+          done
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write + actions:write
           DEPLOY_WORKFLOW: ${{ inputs.trigger_deploy_workflow }}
-          NEW_TAG: ${{ steps.post-release-tag.outputs.tag }}
+          NEW_TAGS: ${{ steps.post-release-tag.outputs.tags }}
       # Notify only when this run actually created a release; a build-only push used to
       # re-announce the previous tag. Same hardened shape as deploy.yml's notifiers: the
       # content is JSON-escaped by toJSON and inserted with printf so tag names cannot break
@@ -303,7 +317,7 @@ jobs:
           curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commits/{3})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tag, github.sha)) }}
+          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commit/{3})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tags, github.sha)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # Delete only when the DOT_ENV secret was actually written by this run: dot_env_path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,9 +213,9 @@ jobs:
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
-      # This tag feeds only the new-release check that gates the deploy trigger, so skip it
-      # (and its fetch cost) for consumers without trigger_deploy_workflow.
-      - if: ${{ inputs.trigger_deploy_workflow }}
+      # This tag feeds the new-release check that gates the deploy trigger and the Discord
+      # notification, so skip it (and its fetch cost) when neither consumer is configured.
+      - if: ${{ inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
         name: Get current latest tag
         id: pre-release-tag
         # The checkout is shallow and tag-less. Fetching tags alone is NOT enough: on a
@@ -224,8 +224,9 @@ jobs:
         # new-release check below succeeds on every run, triggering the deploy workflow even
         # when semantic-release released nothing. (`--unshallow` fails on a complete
         # repository, e.g. persistent self-hosted workspaces, hence the conditional.)
-        # Tolerate fetch failures: an empty tag at worst re-dispatches the deploy for an
-        # existing release, whereas a hard failure here would block the release entirely.
+        # Tolerate fetch failures rather than block the release: a stale (empty) baseline
+        # cannot cause a spurious deploy because the new-release check below also requires
+        # the tag to point at the commit this run released.
         run: |
           if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
             git fetch --unshallow --tags --force || true
@@ -249,31 +250,45 @@ jobs:
           HUSKY: 0
           LEFTHOOK: 0
 
-      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
+      - if: ${{ inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
+        name: Check for new release tag
+        id: post-release-tag
+        # semantic-release creates the tag locally before pushing, so tolerate a failed
+        # fetch here instead of failing the job after a successful release. `created`
+        # additionally requires the tag to point at the commit this run built: a stale
+        # baseline (failed pre-release fetch) or a tag published by an overlapping run can
+        # then never re-trigger a deploy for a release this run did not create. Tag names
+        # may contain shell metacharacters, so they are passed via env, never interpolated
+        # into the script.
+        run: |
+          git fetch --tags --force || true
+          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo '')
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          if [[ -n "$NEW_TAG" && "$NEW_TAG" != "$PRE_TAG" && "$(git rev-parse "$NEW_TAG^{commit}" 2>/dev/null)" == "$GITHUB_SHA" ]]; then
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PRE_TAG: ${{ steps.pre-release-tag.outputs.tag }}
+      # Notify only when this run actually created a release; a build-only push used to
+      # re-announce the previous tag.
+      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
         run: |
           curl -X POST -H "Content-Type: application/json" \
                --data "{
                   \"username\": \"WillBooster Bot\",
                   \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})の最新版 ([$(git describe --always --tags)](https://github.com/${{ github.repository }}/commits/$(git describe --always --tags))) をリリースしました。\"
+                  \"content\": \"[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})の最新版 ([$NEW_TAG](https://github.com/${{ github.repository }}/commits/$NEW_TAG)) をリリースしました。\"
                }" \
                ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      - if: ${{ inputs.trigger_deploy_workflow }}
-        name: Check for new release tag
-        id: post-release-tag
-        run: |
-          git fetch --tags --force
-          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo '')
-          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
-          if [[ -n "$NEW_TAG" && "$NEW_TAG" != "${{ steps.pre-release-tag.outputs.tag }}" ]]; then
-            echo "created=true" >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          NEW_TAG: ${{ steps.post-release-tag.outputs.tag }}
       - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
-        run: gh workflow run ${{ inputs.trigger_deploy_workflow }} --ref ${{ steps.post-release-tag.outputs.tag }}
+        run: gh workflow run "$DEPLOY_WORKFLOW" --ref "$NEW_TAG"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write + actions:write
+          DEPLOY_WORKFLOW: ${{ inputs.trigger_deploy_workflow }}
+          NEW_TAG: ${{ steps.post-release-tag.outputs.tag }}
 
       # Delete only when the DOT_ENV secret was actually written by this run: dot_env_path
       # defaults to .env, which some private repos commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,11 +228,16 @@ jobs:
       # whenever the remote branch head has moved past this run's commit.
       - name: Check whether this run is stale
         id: stale-check
+        # Branch-triggered runs only: a tag/dispatch ref has no refs/heads entry. An EMPTY
+        # remote head means the branch was deleted — a deletion push still triggers the
+        # workflow with GITHUB_SHA reset to the default branch, which must never be released.
         run: |
-          REMOTE_HEAD=$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | cut -f1)
-          if [[ -n "$REMOTE_HEAD" && "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
-            echo "::warning::Skipping the release: $GITHUB_REF_NAME has moved to $REMOTE_HEAD; a newer run will release it."
-            echo "stale=true" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/heads/* ]]; then
+            REMOTE_HEAD=$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | cut -f1)
+            if [[ "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
+              echo "::warning::Skipping the release: $GITHUB_REF_NAME is at '$REMOTE_HEAD', not $GITHUB_SHA (branch moved or deleted)."
+              echo "stale=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
       # This baseline feeds the new-release check that gates the deploy trigger and the
       # Discord notification, so skip it (and its fetch cost) when neither is configured.
@@ -303,6 +308,7 @@ jobs:
           git tag --list | sort > "$RUNNER_TEMP/tags-after-release.txt"
           NEW_TAGS=''
           NEW_COMMIT=''
+          UNRESOLVED_TAGS=''
           while IFS= read -r tag; do
             TAG_COMMIT=$(git rev-parse --verify --end-of-options "refs/tags/$tag^{commit}" 2>/dev/null) || continue
             git merge-base --is-ancestor "$GITHUB_SHA" "$TAG_COMMIT" 2>/dev/null || continue
@@ -321,8 +327,11 @@ jobs:
               fi
               if [[ $rc -eq 2 ]]; then continue; fi
               if [[ $rc -ne 0 ]]; then
+                # Keep scanning: one unverifiable tag must not swallow the side effects of
+                # tags that DID verify (a re-run cannot re-detect any of them).
                 echo "::error::Could not verify refs/tags/$tag on origin (git ls-remote exited $rc); if it is published, dispatch the deploy manually with \`gh workflow run <workflow> --ref $tag\`."
-                exit 1
+                UNRESOLVED_TAGS="${UNRESOLVED_TAGS:+$UNRESOLVED_TAGS }$tag"
+                continue
               fi
             fi
             NEW_TAGS="${NEW_TAGS:+$NEW_TAGS }$tag"
@@ -334,6 +343,11 @@ jobs:
           if [[ -n "$NEW_TAGS" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
+          if [[ -n "${UNRESOLVED_TAGS:-}" ]]; then
+            exit 1
+          fi
+      # outputs.created is still written when the step later fails on an unverifiable tag,
+      # and !cancelled() lets the verified tags' side effects proceed.
       - if: ${{ !cancelled() && inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
         # Word splitting on $NEW_TAGS is intended: refnames cannot contain spaces. Each tag
@@ -368,7 +382,9 @@ jobs:
       - if: ${{ !cancelled() && env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
         run: |
           printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","allowed_mentions":{"parse":[]},"content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
-          curl --retry 2 --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          : # wait=true makes Discord confirm the message was saved; without it an unsaved
+          : # message still returns success and the announcement is silently lost.
+          curl --retry 2 --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL?wait=true"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
           # The link targets the tagged commit, which release scripts like npm version may

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,11 +234,14 @@ jobs:
         # a pre-existing tag to this run (e.g. a re-run of an already-released commit) and
         # re-dispatch its deploy.
         run: |
+          # --prune-tags drops runner-local tags absent from the remote (persistent
+          # self-hosted workspaces can retain a tag from a run whose push failed), so the
+          # baseline reflects the remote tag namespace.
           fetch_tags() {
             if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-              git fetch --unshallow --tags --force
+              git fetch --unshallow --prune --prune-tags --tags --force
             else
-              git fetch --tags --force
+              git fetch --prune --prune-tags --tags --force
             fi
           }
           fetch_tags || { sleep 10; fetch_tags; }
@@ -277,27 +280,41 @@ jobs:
         # workspace package on the same commit. The qualified ref + --end-of-options keeps
         # tag names starting with '-' from being parsed as options.
         run: |
-          git fetch --tags --force || true
+          git fetch --prune --prune-tags --tags --force || true
           git tag --list | sort > "$RUNNER_TEMP/tags-after-release.txt"
           NEW_TAGS=''
+          NEW_COMMIT=''
           while IFS= read -r tag; do
             TAG_COMMIT=$(git rev-parse --verify --end-of-options "refs/tags/$tag^{commit}" 2>/dev/null) || continue
-            if git merge-base --is-ancestor "$GITHUB_SHA" "$TAG_COMMIT" 2>/dev/null; then
-              NEW_TAGS="${NEW_TAGS:+$NEW_TAGS }$tag"
-            fi
+            git merge-base --is-ancestor "$GITHUB_SHA" "$TAG_COMMIT" 2>/dev/null || continue
+            # Only remotely published tags count: a release script may tag locally and then
+            # fail to push, and `gh workflow run --ref` cannot resolve a local-only tag.
+            git ls-remote --exit-code --tags origin "refs/tags/$tag" > /dev/null 2>&1 || continue
+            NEW_TAGS="${NEW_TAGS:+$NEW_TAGS }$tag"
+            NEW_COMMIT=${NEW_COMMIT:-$TAG_COMMIT}
           done < <(comm -13 "$RUNNER_TEMP/tags-before-release.txt" "$RUNNER_TEMP/tags-after-release.txt")
           echo "tags=$NEW_TAGS" >> "$GITHUB_OUTPUT"
           echo "tag=${NEW_TAGS%% *}" >> "$GITHUB_OUTPUT"
+          echo "commit=$NEW_COMMIT" >> "$GITHUB_OUTPUT"
           if [[ -n "$NEW_TAGS" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
       - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
-        # Word splitting on $NEW_TAGS is intended: refnames cannot contain spaces.
+        # Word splitting on $NEW_TAGS is intended: refnames cannot contain spaces. Each tag
+        # is retried once and a failure does not abort the remaining tags. NOTE: a re-run of
+        # this job cannot re-detect the tags (its baseline already contains them), so if
+        # dispatches still fail, recover manually with
+        # `gh workflow run <deploy workflow> --ref <tag>`.
         run: |
+          STATUS=0
           for tag in $NEW_TAGS; do
-            gh workflow run "$DEPLOY_WORKFLOW" --ref "$tag"
+            gh workflow run "$DEPLOY_WORKFLOW" --ref "$tag" || gh workflow run "$DEPLOY_WORKFLOW" --ref "$tag" || {
+              echo "::error::Failed to dispatch $DEPLOY_WORKFLOW for $tag; run \`gh workflow run $DEPLOY_WORKFLOW --ref $tag\` manually."
+              STATUS=1
+            }
           done
+          exit $STATUS
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write + actions:write
           DEPLOY_WORKFLOW: ${{ inputs.trigger_deploy_workflow }}
@@ -314,10 +331,12 @@ jobs:
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
         run: |
           printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","allowed_mentions":{"parse":[]},"content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
-          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          curl --retry 2 --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
           rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commit/{3})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tags, github.sha)) }}
+          # The link targets the tagged commit, which release scripts like npm version may
+          # create on top of github.sha.
+          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commit/{3})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tags, steps.post-release-tag.outputs.commit)) }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # Delete only when the DOT_ENV secret was actually written by this run: dot_env_path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,9 @@ jobs:
         # workspace package on the same commit. The qualified ref + --end-of-options keeps
         # tag names starting with '-' from being parsed as options.
         run: |
+          check_remote_tag() {
+            git ls-remote --exit-code --tags origin "refs/tags/$1" > /dev/null 2>&1
+          }
           git fetch --prune --prune-tags --tags --force || true
           git tag --list | sort > "$RUNNER_TEMP/tags-after-release.txt"
           NEW_TAGS=''
@@ -289,7 +292,21 @@ jobs:
             git merge-base --is-ancestor "$GITHUB_SHA" "$TAG_COMMIT" 2>/dev/null || continue
             # Only remotely published tags count: a release script may tag locally and then
             # fail to push, and `gh workflow run --ref` cannot resolve a local-only tag.
-            git ls-remote --exit-code --tags origin "refs/tags/$tag" > /dev/null 2>&1 || continue
+            # ls-remote --exit-code returns 2 for a missing ref; any other failure is a
+            # transport error, which must not silently drop a published release (a re-run
+            # cannot re-detect it), so retry once and then fail loudly.
+            if ! check_remote_tag "$tag"; then
+              rc=$?
+              if [[ $rc -ne 2 ]]; then
+                sleep 5
+                check_remote_tag "$tag" && rc=0 || rc=$?
+              fi
+              if [[ $rc -eq 2 ]]; then continue; fi
+              if [[ $rc -ne 0 ]]; then
+                echo "::error::Could not verify refs/tags/$tag on origin (git ls-remote exited $rc); if it is published, dispatch the deploy manually with \`gh workflow run <workflow> --ref $tag\`."
+                exit 1
+              fi
+            fi
             NEW_TAGS="${NEW_TAGS:+$NEW_TAGS }$tag"
             NEW_COMMIT=${NEW_COMMIT:-$TAG_COMMIT}
           done < <(comm -13 "$RUNNER_TEMP/tags-before-release.txt" "$RUNNER_TEMP/tags-after-release.txt")
@@ -328,7 +345,9 @@ jobs:
       # recoverable by a re-run (the re-run's baseline already contains the tag).
       # allowed_mentions is emptied because the tag name lands in Discord Markdown, and the
       # commit link uses the SHA so tag names need no URL-encoding.
-      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
+      # !cancelled(): the announcement of a created release must still go out when a
+      # deploy dispatch failed (the implicit success() would skip it, unrecoverably).
+      - if: ${{ !cancelled() && env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
         run: |
           printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","allowed_mentions":{"parse":[]},"content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
           curl --retry 2 --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,9 +222,21 @@ jobs:
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
+      # After waiting in the concurrency queue, a run can be older than the branch head a
+      # later run already released from; releasing from the stale checkout could publish a
+      # lower version after a higher one. GitHub does not guarantee queue ordering, so skip
+      # whenever the remote branch head has moved past this run's commit.
+      - name: Check whether this run is stale
+        id: stale-check
+        run: |
+          REMOTE_HEAD=$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | cut -f1)
+          if [[ -n "$REMOTE_HEAD" && "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
+            echo "::warning::Skipping the release: $GITHUB_REF_NAME has moved to $REMOTE_HEAD; a newer run will release it."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
       # This baseline feeds the new-release check that gates the deploy trigger and the
       # Discord notification, so skip it (and its fetch cost) when neither is configured.
-      - if: ${{ inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
+      - if: ${{ steps.stale-check.outputs.stale != 'true' && (inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true') }}
         name: Record the tags existing before the release
         id: pre-release-tag
         # The checkout is shallow and tag-less, so fetch the tags first (`--unshallow` on a
@@ -246,7 +258,8 @@ jobs:
           }
           fetch_tags || { sleep 10; fetch_tags; }
           git tag --list | sort > "$RUNNER_TEMP/tags-before-release.txt"
-      - name: Release
+      - if: ${{ steps.stale-check.outputs.stale != 'true' }}
+        name: Release
         run: |
           if [[ "$(cat package.json)" == *'"release":'* ]]; then
             ${{ steps.env-info.outputs.runner }} run release
@@ -262,7 +275,10 @@ jobs:
           HUSKY: 0
           LEFTHOOK: 0
 
-      - if: ${{ (inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true') && steps.pre-release-tag.outcome == 'success' }}
+      # !cancelled(): semantic-release can fail AFTER pushing its tag (e.g. a later publish
+      # plugin); the pushed release must still be detected and deployed — a re-run cannot
+      # re-detect it, and the job still fails via the Release step's own outcome.
+      - if: ${{ !cancelled() && (inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true') && steps.pre-release-tag.outcome == 'success' }}
         name: Check for new release tag
         id: post-release-tag
         # semantic-release creates the tag locally before pushing, so tolerate a failed
@@ -295,7 +311,9 @@ jobs:
             # ls-remote --exit-code returns 2 for a missing ref; any other failure is a
             # transport error, which must not silently drop a published release (a re-run
             # cannot re-detect it), so retry once and then fail loudly.
-            if ! check_remote_tag "$tag"; then
+            if check_remote_tag "$tag"; then
+              :
+            else
               rc=$?
               if [[ $rc -ne 2 ]]; then
                 sleep 5
@@ -316,7 +334,7 @@ jobs:
           if [[ -n "$NEW_TAGS" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
-      - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
+      - if: ${{ !cancelled() && inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
         # Word splitting on $NEW_TAGS is intended: refnames cannot contain spaces. Each tag
         # is retried once and a failure does not abort the remaining tags. NOTE: a re-run of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,11 @@ on:
 jobs:
   release:
     if: ${{ (!inputs.target_organization || github.repository_owner == inputs.target_organization) && (!inputs.ignore_renovate || (github.event.head_commit.author.username != 'renovate-bot' && github.event.head_commit.author.username != 'renovate[bot]')) }}
-    # Serialize releases per repository/ref: with overlapping runs, a run could observe the
-    # tag another run just published at the same commit and re-dispatch its deploy.
+    # Serialize releases per repository (not per ref — two refs can point at the same
+    # commit): with overlapping runs, a run could observe the tag another run just
+    # published at its own commit and re-dispatch that release's deploy.
     concurrency:
-      group: release-${{ github.repository }}-${{ github.ref }}
+      group: release-${{ github.repository }}
       cancel-in-progress: false
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || fromJSON('["self-hosted", "medium"]') }}
     env:
@@ -280,19 +281,6 @@ jobs:
           if [[ -n "$NEW_TAG" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
-      # Notify only when this run actually created a release; a build-only push used to
-      # re-announce the previous tag. Same hardened shape as deploy.yml's notifiers: the
-      # content is JSON-escaped by toJSON and inserted with printf so tag names cannot break
-      # the JSON or the shell, and --fail-with-body surfaces webhook rejections instead of
-      # silently losing the announcement.
-      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
-        run: |
-          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
-          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
-          rm -f "$RUNNER_TEMP/discord-payload.json"
-        env:
-          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commits/{2})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tag)) }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
         run: gh workflow run "$DEPLOY_WORKFLOW" --ref "$NEW_TAG"
@@ -300,6 +288,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write + actions:write
           DEPLOY_WORKFLOW: ${{ inputs.trigger_deploy_workflow }}
           NEW_TAG: ${{ steps.post-release-tag.outputs.tag }}
+      # Notify only when this run actually created a release; a build-only push used to
+      # re-announce the previous tag. Same hardened shape as deploy.yml's notifiers: the
+      # content is JSON-escaped by toJSON and inserted with printf so tag names cannot break
+      # the JSON or the shell, and --fail-with-body surfaces webhook rejections instead of
+      # silently losing the announcement. This step must stay AFTER the deploy trigger:
+      # under bash -e a webhook rejection fails the job, and the deploy dispatch is not
+      # recoverable by a re-run (the re-run's baseline already contains the tag).
+      # allowed_mentions is emptied because the tag name lands in Discord Markdown, and the
+      # commit link uses the SHA so tag names need no URL-encoding.
+      - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
+        run: |
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","allowed_mentions":{"parse":[]},"content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
+        env:
+          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commits/{3})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tag, github.sha)) }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       # Delete only when the DOT_ENV secret was actually written by this run: dot_env_path
       # defaults to .env, which some private repos commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,17 +228,43 @@ jobs:
       # whenever the remote branch head has moved past this run's commit.
       - name: Check whether this run is stale
         id: stale-check
-        # Branch-triggered runs only: a tag/dispatch ref has no refs/heads entry. An EMPTY
+        # Branch-triggered runs only: a tag/dispatch ref has no refs/heads entry. A missing
         # remote head means the branch was deleted — a deletion push still triggers the
-        # workflow with GITHUB_SHA reset to the default branch, which must never be released.
+        # workflow with GITHUB_SHA reset to the default branch, which must never be
+        # released. ls-remote's status is read un-piped with --exit-code (2 = ref absent;
+        # anything else non-zero is a transport error, retried once then failed loudly —
+        # nothing has been released yet, so a re-run recovers cleanly). A moved head marks
+        # the run stale only when a successor run exists for the new head: renovate
+        # branch-automerges and [skip ci] pushes move the head WITHOUT creating a run, and
+        # skipping then would silently drop this commit's release.
         run: |
           if [[ "$GITHUB_REF" == refs/heads/* ]]; then
-            REMOTE_HEAD=$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | cut -f1)
-            if [[ "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
-              echo "::warning::Skipping the release: $GITHUB_REF_NAME is at '$REMOTE_HEAD', not $GITHUB_SHA (branch moved or deleted)."
+            ls_head() { git ls-remote --exit-code origin "refs/heads/$GITHUB_REF_NAME"; }
+            LS_OUT=$(ls_head) && rc=0 || rc=$?
+            if [[ $rc -ne 0 && $rc -ne 2 ]]; then
+              sleep 5
+              LS_OUT=$(ls_head) && rc=0 || rc=$?
+            fi
+            if [[ $rc -ne 0 && $rc -ne 2 ]]; then
+              echo "::error::Could not read refs/heads/$GITHUB_REF_NAME on origin (git ls-remote exited $rc); nothing has been released — re-run the job."
+              exit 1
+            fi
+            if [[ $rc -eq 2 ]]; then
+              echo "::warning::Skipping the release: $GITHUB_REF_NAME was deleted."
               echo "stale=true" >> "$GITHUB_OUTPUT"
+            else
+              REMOTE_HEAD=$(printf '%s' "$LS_OUT" | cut -f1)
+              if [[ "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
+                SUCCESSOR_RUNS=$(gh run list --commit "$REMOTE_HEAD" --workflow "$GITHUB_WORKFLOW" --json databaseId --jq length 2>/dev/null || echo 0)
+                if [[ "$SUCCESSOR_RUNS" != "0" ]]; then
+                  echo "::warning::Skipping the release: $GITHUB_REF_NAME moved to $REMOTE_HEAD and a newer run exists for it."
+                  echo "stale=true" >> "$GITHUB_OUTPUT"
+                fi
+              fi
             fi
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
       # This baseline feeds the new-release check that gates the deploy trigger and the
       # Discord notification, so skip it (and its fetch cost) when neither is configured.
       - if: ${{ steps.stale-check.outputs.stale != 'true' && (inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,13 @@ jobs:
             else
               REMOTE_HEAD=$(printf '%s' "$LS_OUT" | cut -f1)
               if [[ "$REMOTE_HEAD" != "$GITHUB_SHA" ]]; then
-                SUCCESSOR_RUNS=$(gh run list --commit "$REMOTE_HEAD" --workflow "$GITHUB_WORKFLOW" --json databaseId --jq length 2>/dev/null || echo 0)
+                : # A gh failure must not silently disable this guard (nor silently skip the
+                : # release): retry once, then fail loudly — nothing has been released yet.
+                run_count() { gh run list --commit "$REMOTE_HEAD" --workflow "$GITHUB_WORKFLOW" --json databaseId --jq length; }
+                SUCCESSOR_RUNS=$(run_count) || { sleep 5; SUCCESSOR_RUNS=$(run_count); } || {
+                  echo "::error::Could not list workflow runs for $REMOTE_HEAD; nothing has been released — re-run the job."
+                  exit 1
+                }
                 if [[ "$SUCCESSOR_RUNS" != "0" ]]; then
                   echo "::warning::Skipping the release: $GITHUB_REF_NAME moved to $REMOTE_HEAD and a newer run exists for it."
                   echo "stale=true" >> "$GITHUB_OUTPUT"
@@ -364,7 +370,6 @@ jobs:
             NEW_COMMIT=${NEW_COMMIT:-$TAG_COMMIT}
           done < <(comm -13 "$RUNNER_TEMP/tags-before-release.txt" "$RUNNER_TEMP/tags-after-release.txt")
           echo "tags=$NEW_TAGS" >> "$GITHUB_OUTPUT"
-          echo "tag=${NEW_TAGS%% *}" >> "$GITHUB_OUTPUT"
           echo "commit=$NEW_COMMIT" >> "$GITHUB_OUTPUT"
           if [[ -n "$NEW_TAGS" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,12 @@ jobs:
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
       - name: Get current latest tag
         id: pre-release-tag
-        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+        # The checkout is shallow and tag-less, so fetch tags first; otherwise this step
+        # always reports an empty tag and the new-release check below succeeds on every
+        # run, triggering the deploy workflow even when semantic-release released nothing.
+        run: |
+          git fetch --tags --force
+          echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
       - name: Release
         run: |
           if [[ "$(cat package.json)" == *'"release":'* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,13 +213,25 @@ jobs:
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
-      - name: Get current latest tag
+      # This tag feeds only the new-release check that gates the deploy trigger, so skip it
+      # (and its fetch cost) for consumers without trigger_deploy_workflow.
+      - if: ${{ inputs.trigger_deploy_workflow }}
+        name: Get current latest tag
         id: pre-release-tag
-        # The checkout is shallow and tag-less, so fetch tags first; otherwise this step
-        # always reports an empty tag and the new-release check below succeeds on every
-        # run, triggering the deploy workflow even when semantic-release released nothing.
+        # The checkout is shallow and tag-less. Fetching tags alone is NOT enough: on a
+        # shallow clone `git describe` requires the tagged commit to be reachable from HEAD,
+        # so unshallow first; otherwise this step always reports an empty tag and the
+        # new-release check below succeeds on every run, triggering the deploy workflow even
+        # when semantic-release released nothing. (`--unshallow` fails on a complete
+        # repository, e.g. persistent self-hosted workspaces, hence the conditional.)
+        # Tolerate fetch failures: an empty tag at worst re-dispatches the deploy for an
+        # existing release, whereas a hard failure here would block the release entirely.
         run: |
-          git fetch --tags --force
+          if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+            git fetch --unshallow --tags --force || true
+          else
+            git fetch --tags --force || true
+          fi
           echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
       - name: Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ on:
 jobs:
   release:
     if: ${{ (!inputs.target_organization || github.repository_owner == inputs.target_organization) && (!inputs.ignore_renovate || (github.event.head_commit.author.username != 'renovate-bot' && github.event.head_commit.author.username != 'renovate[bot]')) }}
+    # Serialize releases per repository/ref: with overlapping runs, a run could observe the
+    # tag another run just published at the same commit and re-dispatch its deploy.
+    concurrency:
+      group: release-${{ github.repository }}-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || fromJSON('["self-hosted", "medium"]') }}
     env:
       FORCE_COLOR: 3
@@ -213,27 +218,27 @@ jobs:
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
-      # This tag feeds the new-release check that gates the deploy trigger and the Discord
-      # notification, so skip it (and its fetch cost) when neither consumer is configured.
+      # This baseline feeds the new-release check that gates the deploy trigger and the
+      # Discord notification, so skip it (and its fetch cost) when neither is configured.
       - if: ${{ inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
-        name: Get current latest tag
+        name: Record the tags existing before the release
         id: pre-release-tag
-        # The checkout is shallow and tag-less. Fetching tags alone is NOT enough: on a
-        # shallow clone `git describe` requires the tagged commit to be reachable from HEAD,
-        # so unshallow first; otherwise this step always reports an empty tag and the
-        # new-release check below succeeds on every run, triggering the deploy workflow even
-        # when semantic-release released nothing. (`--unshallow` fails on a complete
-        # repository, e.g. persistent self-hosted workspaces, hence the conditional.)
-        # Tolerate fetch failures rather than block the release: a stale (empty) baseline
-        # cannot cause a spurious deploy because the new-release check below also requires
-        # the tag to point at the commit this run released.
+        # The checkout is shallow and tag-less, so fetch the tags first (`--unshallow` on a
+        # shallow clone so the refs resolve; it fails on a complete repository, e.g.
+        # persistent self-hosted workspaces, hence the conditional). Retry once, then FAIL:
+        # nothing has been published yet, and an unknown baseline could otherwise attribute
+        # a pre-existing tag to this run (e.g. a re-run of an already-released commit) and
+        # re-dispatch its deploy.
         run: |
-          if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-            git fetch --unshallow --tags --force || true
-          else
-            git fetch --tags --force || true
-          fi
-          echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          fetch_tags() {
+            if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+              git fetch --unshallow --tags --force
+            else
+              git fetch --tags --force
+            fi
+          }
+          fetch_tags || { sleep 10; fetch_tags; }
+          git tag --list | sort > "$RUNNER_TEMP/tags-before-release.txt"
       - name: Release
         run: |
           if [[ "$(cat package.json)" == *'"release":'* ]]; then
@@ -250,38 +255,44 @@ jobs:
           HUSKY: 0
           LEFTHOOK: 0
 
-      - if: ${{ inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true' }}
+      - if: ${{ (inputs.trigger_deploy_workflow || env.HAS_DISCORD_WEBHOOK_URL == 'true') && steps.pre-release-tag.outcome == 'success' }}
         name: Check for new release tag
         id: post-release-tag
         # semantic-release creates the tag locally before pushing, so tolerate a failed
-        # fetch here instead of failing the job after a successful release. `created`
-        # additionally requires the tag to point at the commit this run built: a stale
-        # baseline (failed pre-release fetch) or a tag published by an overlapping run can
-        # then never re-trigger a deploy for a release this run did not create. Tag names
-        # may contain shell metacharacters, so they are passed via env, never interpolated
-        # into the script.
+        # fetch here instead of failing the job after a successful release. The new tag is
+        # detected as a set difference against the baseline AND must point at the commit
+        # this run built, so a tag published by an overlapping run or an already-released
+        # commit can never re-trigger a deploy. The set difference (not `git describe`,
+        # which prefers annotated tags and can hide semantic-release's lightweight tag
+        # behind an annotated one on the same commit) identifies the created tag. Tag names
+        # may contain shell metacharacters, so they reach later scripts only via env.
         run: |
           git fetch --tags --force || true
-          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo '')
+          git tag --list | sort > "$RUNNER_TEMP/tags-after-release.txt"
+          NEW_TAG=''
+          while IFS= read -r tag; do
+            if [[ "$(git rev-parse "$tag^{commit}" 2>/dev/null)" == "$GITHUB_SHA" ]]; then
+              NEW_TAG=$tag
+              break
+            fi
+          done < <(comm -13 "$RUNNER_TEMP/tags-before-release.txt" "$RUNNER_TEMP/tags-after-release.txt")
           echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
-          if [[ -n "$NEW_TAG" && "$NEW_TAG" != "$PRE_TAG" && "$(git rev-parse "$NEW_TAG^{commit}" 2>/dev/null)" == "$GITHUB_SHA" ]]; then
+          if [[ -n "$NEW_TAG" ]]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          PRE_TAG: ${{ steps.pre-release-tag.outputs.tag }}
       # Notify only when this run actually created a release; a build-only push used to
-      # re-announce the previous tag.
+      # re-announce the previous tag. Same hardened shape as deploy.yml's notifiers: the
+      # content is JSON-escaped by toJSON and inserted with printf so tag names cannot break
+      # the JSON or the shell, and --fail-with-body surfaces webhook rejections instead of
+      # silently losing the announcement.
       - if: ${{ env.HAS_DISCORD_WEBHOOK_URL == 'true' && steps.post-release-tag.outputs.created == 'true' }}
         run: |
-          curl -X POST -H "Content-Type: application/json" \
-               --data "{
-                  \"username\": \"WillBooster Bot\",
-                  \"avatar_url\": \"https://avatars.githubusercontent.com/u/98675783\",
-                  \"content\": \"[${{ github.event.repository.name }}](${{ github.event.repository.html_url }})の最新版 ([$NEW_TAG](https://github.com/${{ github.repository }}/commits/$NEW_TAG)) をリリースしました。\"
-               }" \
-               ${{ secrets.DISCORD_WEBHOOK_URL }}
+          printf '{"username":"WillBooster Bot","avatar_url":"https://avatars.githubusercontent.com/u/98675783","content":%s}' "$CONTENT_JSON" > "$RUNNER_TEMP/discord-payload.json"
+          curl --fail-with-body -X POST -H "Content-Type: application/json" --data @"$RUNNER_TEMP/discord-payload.json" "$DISCORD_WEBHOOK_URL"
+          rm -f "$RUNNER_TEMP/discord-payload.json"
         env:
-          NEW_TAG: ${{ steps.post-release-tag.outputs.tag }}
+          CONTENT_JSON: ${{ toJSON(format('[{0}]({1})の最新版 ([{2}]({1}/commits/{2})) をリリースしました。', github.event.repository.name, github.event.repository.html_url, steps.post-release-tag.outputs.tag)) }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       - if: ${{ inputs.trigger_deploy_workflow && steps.post-release-tag.outputs.created == 'true' }}
         name: Trigger deploy workflow
         run: gh workflow run "$DEPLOY_WORKFLOW" --ref "$NEW_TAG"


### PR DESCRIPTION
The release job's checkout is shallow and tag-less, so
`git describe --tags` always returned empty before semantic-release
ran. The post-release comparison then saw '' != <latest tag> and
triggered the deploy workflow on every release-branch push, even when
semantic-release created no new release (observed in
WillBooster/cheerlings: a build:-only push re-dispatched the desktop
release build for the existing v1.0.0 tag).
