### PR TITLE
build: migrate to Bun isolated installs with the global store

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,8 +2,10 @@ env = false
 telemetry = false
 
 [install]
-exact = false
-linker = "hoisted"
+exact = true
+globalStore = true
+linker = "isolated"
+publicHoistPattern = ["tsx", "undici-types"]
 minimumReleaseAge = 432000 # 5 days
 minimumReleaseAgeExcludes = [
   "@exercode/problem-utils",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "cleanup": "bun run format",
     "format": "sort-package-json",
-    "postinstall": "husky || true",
     "pre-push": "echo 'start pre-push'; sleep 60; bun run sync",
     "prepare": "lefthook install || true",
     "sync": "one-way-git-sync -v -i node_modules -i renovate.json -d git@github.com:WillBoosterLab/reusable-workflows.git",


### PR DESCRIPTION
## Summary

- Migrate `bunfig.toml` from `linker = "hoisted"` to the org-standard isolated installs backed by the shared global store (`linker = "isolated"` + `globalStore = true` + `publicHoistPattern`), and align `exact = true` with the wbfy template.
- Remove the dead `postinstall: "husky || true"` script; the repository already uses lefthook via `prepare`, and husky is not a dependency.

This repository has no TypeScript sources and only four devDependencies, so the migration required no phantom-dependency or `undici-types` fixes. `bun.lock` is unchanged (no resolution churn); `node_modules/.bun` with global-store symlinks was verified after a clean reinstall, and `bun verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
