### PR TITLE
refactor: extract the fnox check and skip-worktree cleanup into composite actions

### DIFF
--- a/.github/actions/check-fnox-secrets/action.yml
+++ b/.github/actions/check-fnox-secrets/action.yml
@@ -30,7 +30,9 @@ runs:
         # for a directory with no fnox configuration.
         run_check() (
           cd "$1" || exit 1
-          [[ -n "$(FNOX_NON_INTERACTIVE=true fnox config-files 2> /dev/null)" ]] || exit 0
+          # A failing `fnox config-files` (e.g. a broken fnox.toml) must fail the check, not skip it.
+          config_files="$(FNOX_NON_INTERACTIVE=true fnox config-files)" || exit 1
+          [[ -n "$config_files" ]] || exit 0
           FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null
         )
         report() {

--- a/.github/actions/check-fnox-secrets/action.yml
+++ b/.github/actions/check-fnox-secrets/action.yml
@@ -1,0 +1,51 @@
+name: Check fnox secrets
+description: >-
+  Validate that the repository's fnox secrets are resolvable with the provided FNOX_AGE_KEY.
+  fnox exits 0 and silently omits unresolvable secrets by default, and a mere key-presence check
+  cannot tell a wrong key from a config needing no key at all (plaintext defaults), so this runs a
+  strict-mode resolution once mise installed fnox (--all includes env="exec"/env=false secrets;
+  --no-daemon defeats a stale daemon cache; a defined WB_ENV selects the matching profile like the
+  wb env loader does, and an undefined profile name safely falls back to the base secrets).
+inputs:
+  mode:
+    description: '"error" fails the job on unresolvable secrets; "warning" only annotates the run.'
+    default: error
+  working_directory:
+    description: >-
+      Additional directory whose effective fnox configuration must also resolve (e.g. the deploy
+      script's working directory; fnox resolves configs hierarchically through ancestors).
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Ensure fnox secrets are resolvable
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+      run: |
+        FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
+        if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
+        # `fnox config-files` lists the directory's whole ancestor config chain and prints nothing
+        # for a directory with no fnox configuration.
+        run_check() (
+          cd "$1" || exit 1
+          [[ -n "$(FNOX_NON_INTERACTIVE=true fnox config-files 2> /dev/null)" ]] || exit 0
+          FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null
+        )
+        report() {
+          if [[ "$MODE" == 'warning' ]]; then
+            echo "::warning::$1; unresolvable age-encrypted values are silently omitted in this run"
+          else
+            echo "::error::$1"
+            exit 1
+          fi
+        }
+        if command -v fnox > /dev/null; then
+          if ! run_check .; then
+            report 'fnox secrets cannot be resolved; check the FNOX_AGE_KEY secret'
+          fi
+          if [[ -n "$WORKING_DIRECTORY" && "$WORKING_DIRECTORY" != '.' ]] && ! run_check "$WORKING_DIRECTORY"; then
+            report "fnox secrets for working_directory \"$WORKING_DIRECTORY\" cannot be resolved; check the FNOX_AGE_KEY secret"
+          fi
+        fi

--- a/.github/actions/clear-stale-skip-worktree/action.yml
+++ b/.github/actions/clear-stale-skip-worktree/action.yml
@@ -1,0 +1,15 @@
+name: Clear stale skip-worktree bits
+description: >-
+  A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that survive every
+  reset/clean and make checkout fail once the consumer deletes the committed file, permanently
+  wedging a persistent workspace — clear them before checkout.
+runs:
+  using: composite
+  steps:
+    - name: Clear stale skip-worktree bits left by a crashed previous run
+      shell: bash
+      run: |
+        if [[ -d .git ]]; then
+          git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
+          git checkout -- . 2> /dev/null || true
+        fi

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -67,19 +67,12 @@ jobs:
         uses: jdx/mise-action@v4.2.0
         with:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
-      # fnox exits 0 and silently omits unresolvable secrets. Autofix only runs cleanup/build
-      # (never app code needing secrets), so warn instead of failing, mirroring test.yml.
-      - name: Warn when fnox.toml secrets cannot be resolved
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          if [[ -f fnox.toml ]] && command -v fnox > /dev/null; then
-            if ! FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null; then
-              echo "::warning::fnox.toml secrets cannot be resolved and are silently omitted in this run; check the FNOX_AGE_KEY secret"
-            fi
-          fi
+      # Autofix only runs cleanup/build (never app code needing secrets), so warn instead of
+      # failing, mirroring test.yml.
+      - name: Warn when fnox secrets cannot be resolved
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
+        with:
+          mode: warning
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,15 +123,8 @@ jobs:
     steps:
       - if: ${{ runner.environment == 'self-hosted' }}
         run: if [[ ! $(docker ps) ]]; then sudo reboot; fi
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
@@ -200,34 +193,10 @@ jobs:
       # omits unresolvable secrets) and would wrongly fail configs needing no age key at all
       # (plaintext defaults), so validate actual resolution in strict mode once mise installed fnox
       # (--all includes env="exec"/env=false secrets; --no-daemon defeats a stale daemon cache).
-      - name: Ensure fnox.toml secrets are resolvable
-        env:
-          WORKING_DIRECTORY: ${{ inputs.working_directory }}
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          # `fnox config-files` lists the directory's whole ancestor config chain, so this also
-          # covers monorepo configs between the root and working_directory; it prints nothing
-          # for a directory with no fnox configuration.
-          run_check() (
-            cd "$1" || exit 1
-            [[ -n "$(FNOX_NON_INTERACTIVE=true fnox config-files 2> /dev/null)" ]] || exit 0
-            FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null
-          )
-          if command -v fnox > /dev/null; then
-            if ! run_check .; then
-              echo "::error::fnox.toml secrets cannot be resolved; check the FNOX_AGE_KEY secret"
-              exit 1
-            fi
-            # The deploy script later runs from working_directory, whose ancestor chain can add or
-            # override secrets, so validate that view too.
-            if [[ -n "$WORKING_DIRECTORY" && "$WORKING_DIRECTORY" != "." ]] && ! run_check "$WORKING_DIRECTORY"; then
-              echo "::error::fnox secrets for working_directory \"$WORKING_DIRECTORY\" cannot be resolved; check the FNOX_AGE_KEY secret"
-              exit 1
-            fi
-          fi
+      - name: Ensure fnox secrets are resolvable
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
+        with:
+          working_directory: ${{ inputs.working_directory }}
       - if: ${{ steps.check-gcloud.outputs.require-gcloud }}
         name: Install gcloud with mise
         uses: nick-fields/retry@dd56f1ca8ca991e2385c18ab6dd36ea7f9fdb55f

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -90,15 +90,8 @@ jobs:
       # registry when installing dependencies; empty when the caller does not provide the secret.
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
     steps:
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - uses: actions/checkout@v7.0.0
         with:
           token: ${{ secrets.GH_TOKEN }}
@@ -136,22 +129,8 @@ jobs:
         uses: jdx/mise-action@v4.2.0
         with:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
-      # A mere FNOX_AGE_KEY presence check cannot catch a wrong key (fnox exits 0 and silently
-      # omits unresolvable secrets) and would wrongly fail configs needing no age key at all
-      # (plaintext defaults), so validate actual resolution in strict mode once mise installed fnox
-      # (--all includes env="exec"/env=false secrets; --no-daemon defeats a stale daemon cache).
-      - name: Ensure fnox.toml secrets are resolvable
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          if [[ -f fnox.toml ]] && command -v fnox > /dev/null; then
-            if ! FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null; then
-              echo "::error::fnox.toml secrets cannot be resolved; check the FNOX_AGE_KEY secret"
-              exit 1
-            fi
-          fi
+      - name: Ensure fnox secrets are resolvable
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,15 +73,8 @@ jobs:
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - uses: actions/checkout@v7.0.0
       # The secret is passed via env and written with printf so that quotes or backslashes in
       # its value cannot break out of the shell command.
@@ -116,22 +109,8 @@ jobs:
         uses: jdx/mise-action@v4.2.0
         with:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
-      # A mere FNOX_AGE_KEY presence check cannot catch a wrong key (fnox exits 0 and silently
-      # omits unresolvable secrets) and would wrongly fail configs needing no age key at all
-      # (plaintext defaults), so validate actual resolution in strict mode once mise installed fnox
-      # (--all includes env="exec"/env=false secrets; --no-daemon defeats a stale daemon cache).
-      - name: Ensure fnox.toml secrets are resolvable
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          if [[ -f fnox.toml ]] && command -v fnox > /dev/null; then
-            if ! FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null; then
-              echo "::error::fnox.toml secrets cannot be resolved; check the FNOX_AGE_KEY secret"
-              exit 1
-            fi
-          fi
+      - name: Ensure fnox secrets are resolvable
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -95,15 +95,8 @@ jobs:
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       WB_ENV: ${{ inputs.environment }}
     steps:
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.branch }}
@@ -151,22 +144,8 @@ jobs:
         uses: jdx/mise-action@v4.2.0
         with:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
-      # A mere FNOX_AGE_KEY presence check cannot catch a wrong key (fnox exits 0 and silently
-      # omits unresolvable secrets) and would wrongly fail configs needing no age key at all
-      # (plaintext defaults), so validate actual resolution in strict mode once mise installed fnox
-      # (--all includes env="exec"/env=false secrets; --no-daemon defeats a stale daemon cache).
-      - name: Ensure fnox.toml secrets are resolvable
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          if [[ -f fnox.toml ]] && command -v fnox > /dev/null; then
-            if ! FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null; then
-              echo "::error::fnox.toml secrets cannot be resolved; check the FNOX_AGE_KEY secret"
-              exit 1
-            fi
-          fi
+      - name: Ensure fnox secrets are resolvable
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
       - name: Show environment information
         id: env-info
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,16 +71,9 @@ jobs:
     outputs:
       json: ${{ steps.detect-node-version-matrix.outputs.json }}
     steps:
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         uses: actions/checkout@v7.0.0
       # We need Node.js only if no version is declared in mise-managed files and no .node-version exists.
@@ -137,15 +130,8 @@ jobs:
         with:
           cancel_others: true
           paths_ignore: ${{ inputs.paths_ignore }}
-      # A crashed run can leave skip-worktree bits (from the .npmrc/dotenv hide steps) that
-      # survive every reset/clean and make checkout fail once the consumer deletes the committed
-      # file, permanently wedging a persistent workspace — clear them before checkout.
       - name: Clear stale skip-worktree bits left by a crashed previous run
-        run: |
-          if [[ -d .git ]]; then
-            git ls-files -v 2> /dev/null | grep '^S ' | cut -c3- | tr '\n' '\0' | xargs -0 git update-index --no-skip-worktree -- 2> /dev/null || true
-            git checkout -- . 2> /dev/null || true
-          fi
+        uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
       - if: ${{ needs.pre.outputs.should_skip != 'true' && !github.event.repository.private }}
         uses: actions/checkout@v7.0.0
       - if: ${{ needs.pre.outputs.should_skip != 'true' && github.event.repository.private }}
@@ -201,21 +187,13 @@ jobs:
         uses: jdx/mise-action@v4.2.0
         with:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
-      # fnox exits 0 and silently omits unresolvable secrets, so a green run proves nothing about
-      # secret-dependent behavior. Unlike deploy's fail-fast check, this only warns: fork pull
-      # requests legitimately run without secrets.
+      # Unlike deploy's fail-fast check, this only warns: fork pull requests legitimately run
+      # without secrets.
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
-        name: Warn when fnox.toml secrets cannot be resolved
-        run: |
-          # A defined WB_ENV selects the matching fnox profile like the wb env loader does; an
-          # undefined profile name safely falls back to the base secrets (verified on fnox 1.30.0).
-          FNOX_ARGS=(--all --format json --no-daemon --if-missing error)
-          if [[ -n "$WB_ENV" ]]; then FNOX_ARGS+=(--profile "$WB_ENV"); fi
-          if [[ -f fnox.toml ]] && command -v fnox > /dev/null; then
-            if ! FNOX_NON_INTERACTIVE=true fnox export "${FNOX_ARGS[@]}" > /dev/null; then
-              echo "::warning::fnox.toml secrets cannot be resolved and are silently omitted in this run; check the FNOX_AGE_KEY secret"
-            fi
-          fi
+        name: Warn when fnox secrets cannot be resolved
+        uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
+        with:
+          mode: warning
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Show environment information
         id: env-info


### PR DESCRIPTION
## Summary

Follow-up consolidation to #442: the fnox resolution check (6 copies with error/warning/working_directory variants) and the crashed-run skip-worktree cleanup (6 copies across 5 workflows) are extracted into composite actions:

- `.github/actions/check-fnox-secrets` — inputs: `mode` (`error`/`warning`), `working_directory`; unifies fnox-config detection on `fnox config-files` (whole ancestor chain) for every workflow, which deploy.yml already used.
- `.github/actions/clear-stale-skip-worktree`

The workflows reference them as `WillBooster/reusable-workflows/.github/actions/...@main` (this repository is public, so the WillBoosterLab mirror's workflows resolve them too; relative `./` action paths would wrongly resolve against the CONSUMER checkout in a called reusable workflow).

## Verification

- All workflow and action files parse as valid YAML.
- Will exercise via a consumer CI re-run after merge (the composite actions resolve at run time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
