### PR TITLE
fix: treat an unversioned fnox mise shim as fnox being absent

### DIFF
--- a/.github/actions/check-fnox-secrets/action.yml
+++ b/.github/actions/check-fnox-secrets/action.yml
@@ -43,7 +43,10 @@ runs:
             exit 1
           fi
         }
-        if command -v fnox > /dev/null; then
+        # `command -v` alone is fooled by mise SHIMS on persistent self-hosted runners: a global
+        # fnox shim exists even for repos that do not pin fnox, and errors with "No version is
+        # set for shim" — which must mean "no fnox here", not a failed check.
+        if command -v fnox > /dev/null && fnox --version > /dev/null 2>&1; then
           if ! run_check .; then
             report 'fnox secrets cannot be resolved; check the FNOX_AGE_KEY secret'
           fi


### PR DESCRIPTION
On persistent self-hosted runners, mise's global fnox SHIM satisfies `command -v fnox` even in repos that do not pin fnox, then errors with `No version is set for shim: fnox` — which the strict `fnox config-files` handling turned into a hard failure for every such repo (e.g. agentic-workflows release run 29646015632). The check now requires `fnox --version` to succeed; an unversioned shim means "no fnox here" and the check is skipped, while fnox-migrated repos (which pin fnox in mise.toml, resolving the shim) keep the full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)