### PR TITLE
fix: keep VERDACCIO_TOKEN away from dependency lifecycle scripts during credentialed installs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -149,11 +149,23 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            # Because bun sometimes fails to install private repos (but, update is okay)
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              # Because bun sometimes fails to install private repos (but, update is okay)
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            : # No lifecycle scripts run here, so a single retry only covers transient network
+            : # failures; a reproducible failure is a resolution, auth or lockfile error.
+            ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }} || \
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             : # Retry the same install first: this is the only network-bound step without a retry, and
             : # letting a transient failure reach the fallback would skip every lifecycle script.
@@ -167,6 +179,33 @@ jobs:
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - name: Fix code
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -331,11 +331,23 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            # Because bun sometimes fails to install private repos (but, update is okay)
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              # Because bun sometimes fails to install private repos (but, update is okay)
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            : # No lifecycle scripts run here, so a single retry only covers transient network
+            : # failures; a reproducible failure is a resolution, auth or lockfile error.
+            ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }} || \
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             : # Retry the same install first: this is the only network-bound step without a retry, and
             : # letting a transient failure reach the fallback would skip every lifecycle script.
@@ -349,6 +361,33 @@ jobs:
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - if: ${{ env.HAS_GCP_SA_KEY_JSON_FOR_FIREBASE == 'true' }}
         name: Create credential file for Firebase

--- a/.github/workflows/gen-pr.yml
+++ b/.github/workflows/gen-pr.yml
@@ -210,10 +210,22 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            : # No lifecycle scripts run here, so a single retry only covers transient network
+            : # failures; a reproducible failure is a resolution, auth or lockfile error.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }} || \
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             : # Retry the same install first: this is the only network-bound step without a retry, and
             : # letting a transient failure reach the fallback would skip every lifecycle script.
@@ -227,6 +239,33 @@ jobs:
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install --no-immutable || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
       - name: Remove .next directory
         run: rm -Rf .next
       - name: Run "test/ci-setup" npm script if exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,11 +194,23 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            # Because bun sometimes fails to install private repos (but, update is okay)
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              # Because bun sometimes fails to install private repos (but, update is okay)
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            : # No lifecycle scripts run here, so a single retry only covers transient network
+            : # failures; a reproducible failure is a resolution, auth or lockfile error.
+            ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }} || \
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             : # Retry the same install first: this is the only network-bound step without a retry, and
             : # letting a transient failure reach the fallback would skip every lifecycle script.
@@ -212,6 +224,33 @@ jobs:
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -166,6 +166,12 @@ jobs:
             YARN=$(yarn -v); echo "yarn: $YARN"
             if [[ "$YARN" == "1."* ]]; then
               echo "yarn-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "skip-scripts-option=--ignore-scripts" >> $GITHUB_OUTPUT
+            elif [[ "$YARN" == "2."* ]]; then
+              : # Yarn 3 renamed Yarn 2's --skip-builds to --mode=skip-build.
+              echo "skip-scripts-option=--skip-builds" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts-option=--mode=skip-build" >> $GITHUB_OUTPUT
             fi
             echo "runner=yarn" >> $GITHUB_OUTPUT
           fi
@@ -220,19 +226,50 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - name: Install dependencies
-        # Unlike the other workflows, even postinstall failures are NOT tolerated here: a maintenance
-        # script run against a half-installed dependency graph could silently misbehave.
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            # Because bun sometimes fails to install private repos (but, update is okay)
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              # Because bun sometimes fails to install private repos (but, update is okay)
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             ${{ steps.env-info.outputs.runner }} install
           fi
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      # Unlike the other workflows, lifecycle failures are NOT tolerated here: a maintenance
+      # script run against a half-installed dependency graph could silently misbehave.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - name: Run "common/ci-setup" npm script if exists
         run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,11 +309,23 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
+      # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
+      # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
-            bun install
+            if [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+              bun install --ignore-scripts
+            else
+              bun install
+            fi
+          elif [[ "$HAS_VERDACCIO_TOKEN" == "true" ]]; then
+            : # No lifecycle scripts run here, so a single retry only covers transient network
+            : # failures; a reproducible failure is a resolution, auth or lockfile error.
+            ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }} || \
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
           else
             : # Retry the same install first: this is the only network-bound step without a retry, and
             : # letting a transient failure reach the fallback would skip every lifecycle script.
@@ -327,6 +339,33 @@ jobs:
         env:
           GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # Replay the lifecycle scripts the credentialed install skipped, in an environment without
+      # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
+      # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the
+      # package manager's cache from the step above, so the private registry is not contacted.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && env.HAS_VERDACCIO_TOKEN == 'true' }}
+        name: Run dependency lifecycle scripts without registry credentials
+        run: |
+          if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
+            : # force a full cache-hit re-link.
+            rm -rf node_modules
+            bun install
+          else
+            if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
+              : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is
+              : # removed; Yarn Berry instead tracks unbuilt packages and rebuilds them itself.
+              rm -rf node_modules
+            fi
+            ${{ steps.env-info.outputs.runner }} install --no-immutable || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
+            }
+          fi
+        env:
+          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run "common/ci-setup" npm script if exists
         run: if grep -q '"common/ci-setup":' package.json; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi


### PR DESCRIPTION
Fixes #449

## Problem

The credentialed "Install dependencies" steps run repository- and dependency-defined `preinstall`/`postinstall` scripts with the step-scoped `VERDACCIO_TOKEN` in the environment, so a same-repository PR can exfiltrate the secret from a lifecycle script (reproduced with bun 1.3.14).

## Design

When `HAS_VERDACCIO_TOKEN == 'true'`, installation is split into two steps:

1. **Credentialed install, scripts disabled** — `bun install --ignore-scripts` / `yarn install --ignore-scripts` (yarn1) / `--skip-builds` (yarn2) / `--mode=skip-build` (yarn3+). This performs authenticated resolution and download; no repository- or dependency-controlled code runs while the token is in the environment.
2. **Tokenless lifecycle replay** (new step, no `VERDACCIO_TOKEN`/secret in `env`) — replays the skipped scripts from the warm package-manager cache, so the private registry is never contacted:
   - **bun / yarn1**: `rm -rf node_modules` + plain re-install (a repeated no-op install does *not* replay skipped scripts — verified empirically).
   - **Yarn Berry**: plain `yarn install`; Berry's install state marks the packages as "must be built because it never has been before" and rebuilds them itself (no `rm` needed).

The job-level `VERDACCIO_TOKEN: ''` keeps `${VERDACCIO_TOKEN}` references in `.npmrc`/`.yarnrc.yml` expanding to an empty string instead of erroring. Repositories without a Verdaccio token keep the previous single-install behavior unchanged.

## Empirical evidence (bun 1.3.14, yarn 1.22.22, yarn 4.9.2)

- Root `preinstall` printing `$VERDACCIO_TOKEN` shows nothing during the credentialed `--ignore-scripts` install; the tokenless replay runs it with an empty value.
- A trusted dependency with a native postinstall (`better-sqlite3`): binary absent after `--ignore-scripts`, absent after a *no-op* re-install (hence the `rm -rf node_modules`), present and functional after the forced cache-hit re-link.
- With the registry made unreachable, the replay install still succeeds from cache when the registry URL is unchanged (bun keys its cache by registry URL).
- yarn1 and Yarn Berry verified with the same root-script + dependency-postinstall fixtures.

## Per-workflow changes

- `test.yml`, `gen-pr.yml`: token branch in the install step (with `--no-immutable` for yarn) + tokenless replay step that keeps the existing postinstall-failure tolerance (`install || install <skip-scripts>`).
- `autofix.yml`, `deploy.yml`, `release.yml`: same, without `--no-immutable`.
- `run-script.yml`: same split but strict (no failure tolerance, matching its existing semantics); its `env-info` step gains the `skip-scripts-option` output the other workflows already compute.
- The `HAS_VERDACCIO_TOKEN` gating and step-scoping from #448 are unchanged.

## Residual notes

- `GH_PKG_READ_TOKEN` remains on both steps: the replay may legitimately need it only on a cache miss for GitHub-registry packages, and unlike `VERDACCIO_TOKEN` there is no job-level empty default, so consumer configs referencing it would otherwise fail to expand. Narrowing it can be a follow-up.
- In a hoisted-linker workspace, a version-conflict duplicate installed into a nested `packages/*/node_modules` survives the root `rm -rf node_modules`; if such a duplicate has a lifecycle script it may not be replayed. Org repos use the isolated linker (everything under the root `node_modules`), so this is theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
