### PR TITLE
fix: select checkout strategy by runner.environment instead of repo visibility

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -13,4 +13,4 @@ jobs:
       - run: |
           pwd
           ls -al
-          echo "${{ !github.event.repository.private || inputs.github_hosted_runner }}"
+          echo "runner.environment: ${{ runner.environment }}"

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -53,9 +53,14 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - if: ${{ needs.pre.outputs.should_skip != 'true' && !github.event.repository.private }}
+      # actions/checkout uses HTTPS + GITHUB_TOKEN, which works on GitHub-hosted runners even for
+      # private repos. The manual SSH checkout below is only viable on self-hosted runners (which
+      # carry an SSH deploy key and a persistent workspace), so the split keys off the actual
+      # runner environment, NOT repository visibility: a private repo forced onto a hosted runner
+      # via `github_hosted_runner`/`runs_on` has no SSH key and must take the actions/checkout path.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && runner.environment != 'self-hosted' }}
         uses: actions/checkout@v7.0.0
-      - if: ${{ needs.pre.outputs.should_skip != 'true' && github.event.repository.private }}
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && runner.environment == 'self-hosted' }}
         # Branch names are attacker-controlled script-injection sources, so they reach the
         # shell only via env and are always quoted.
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -414,6 +414,8 @@ jobs:
             git diff -- . "${excludes[@]}"
             : # Push-back over the SSH origin (to re-trigger downstream workflows) is only wired up
             : # by the self-hosted manual checkout; on hosted runners we fail so the diff is visible.
+            : # RUNNER_ENVIRONMENT is exported to every step by the runner itself (it mirrors the
+            : # runner.environment context, alongside RUNNER_OS/RUNNER_TEMP), so it needs no env: entry.
             if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
               git add -A -- . "${excludes[@]}"
               git commit -m "fix: apply changes of autofix workflow" --no-verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,9 +137,14 @@ jobs:
           paths_ignore: ${{ inputs.paths_ignore }}
       - name: Clear stale skip-worktree bits left by a crashed previous run
         uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main
-      - if: ${{ needs.pre.outputs.should_skip != 'true' && !github.event.repository.private }}
+      # actions/checkout uses HTTPS + GITHUB_TOKEN, which works on GitHub-hosted runners even for
+      # private repos. The manual SSH checkout below is only viable on self-hosted runners (which
+      # carry an SSH deploy key and a persistent workspace), so the split keys off the actual
+      # runner environment, NOT repository visibility: a private repo forced onto a hosted runner
+      # via `github_hosted_runner`/`runs_on` has no SSH key and must take the actions/checkout path.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && runner.environment != 'self-hosted' }}
         uses: actions/checkout@v7.0.0
-      - if: ${{ needs.pre.outputs.should_skip != 'true' && github.event.repository.private }}
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && runner.environment == 'self-hosted' }}
         # Branch names are attacker-controlled script-injection sources, so they reach the
         # shell only via env and are always quoted.
         run: |
@@ -407,7 +412,9 @@ jobs:
           if [[ -n "$(git status --porcelain -- . "${excludes[@]}")" ]]; then
             git status
             git diff -- . "${excludes[@]}"
-            if [[ "${{ github.event.repository.private }}" == "true" ]]; then
+            : # Push-back over the SSH origin (to re-trigger downstream workflows) is only wired up
+            : # by the self-hosted manual checkout; on hosted runners we fail so the diff is visible.
+            if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
               git add -A -- . "${excludes[@]}"
               git commit -m "fix: apply changes of autofix workflow" --no-verify
               git push origin "HEAD:refs/heads/$HEAD_REF" --no-verify


### PR DESCRIPTION
## Customer Summary

- Fixes reusable CI workflows crashing when a private repository is deliberately run on a GitHub-hosted runner (via `github_hosted_runner: true` or a hosted `runs_on`). Such runs previously failed with `git@github.com: Permission denied (publickey)` before any tests could run.
- No configuration change is required from callers; affected repositories will simply start passing again.

## Technical Summary

- `test.yml` and `test-rust.yml` chose their checkout strategy from `github.event.repository.private` alone: public → `actions/checkout` (HTTPS + `GITHUB_TOKEN`), private → a manual SSH `git init`/fetch that only works on self-hosted runners (SSH deploy key + persistent workspace). A private repo forced onto a hosted runner has no SSH key, so it took the SSH path and crashed.
- The step-level checkout choice now keys off `runner.environment` (`!= 'self-hosted'` → `actions/checkout`; `== 'self-hosted'` → SSH checkout). Job-level `runs-on:` expressions keep using visibility + `github_hosted_runner`, since they decide the runner before `runner.environment` exists.
- Consistency refactor (same `runner.environment` idiom): the `test.yml` autofix push-back — which depends on the SSH origin the manual checkout wires up — now branches on `$RUNNER_ENVIRONMENT == self-hosted`; `debug.yml` echoes `runner.environment` instead of a stale expression referencing an undeclared input.

## Why

- Repository visibility is the wrong signal for a step that must know *where the job actually landed*; `github_hosted_runner`/`runs_on` decouple the runner from visibility. `runner.environment` reflects the real runner and matches how this repo already gates runner-specific steps (rust-cache, mise-action cache).

## Testing

- `bun verify` (type check + lint): passed.
- All edited workflows validated as parseable YAML (`js-yaml`).
- PR CI: all workflows passed.
- Multi-agent code review converged with no remaining findings. One finding (that `$RUNNER_ENVIRONMENT` would be empty in shell) was verified invalid against the actions/runner source (`RunnerContext.GetRuntimeEnvironmentVariables` exports every runner-context key as `RUNNER_<KEY>`; `JobRunner` sets the `environment` key), and a clarifying comment was added.

## Notes

- No behavior change for public repos or for private repos on self-hosted runners.
