### PR TITLE
fix: remove unused registry tokens and sanitize Berry plugins during credentialed installs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -150,6 +150,34 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # Yarn Berry loads `.yarnrc.yml` plugins during every yarn command, including the
+      # credentialed install below, so a repository-committed plugin is config-driven code
+      # execution that can read the step-scoped VERDACCIO_TOKEN (#453). Strip the top-level
+      # `plugins:` block for the credentialed install only and restore the original file
+      # right after it, so plugins still apply to the tokenless lifecycle replay. Residual
+      # risk (out of scope here): the committed yarnPath release in .yarn/releases/ also
+      # executes during the credentialed install.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' && steps.env-info.outputs.runner != 'bun' && steps.env-info.outputs.skip-scripts-option != '--ignore-scripts' }}
+        name: Remove plugins from .yarnrc.yml for the credentialed install
+        run: |
+          if [[ ! -f .yarnrc.yml ]]; then exit 0; fi
+          : # Recover the committed content a crashed previous run may have left sanitized
+          : # (the always() restore cannot run when the runner dies, and persistent
+          : # self-hosted workspaces keep the worktree between runs).
+          if git ls-files --error-unmatch -- .yarnrc.yml > /dev/null 2>&1; then
+            git checkout -- .yarnrc.yml 2> /dev/null || true
+          fi
+          YARNRC_BACKUP=$(mktemp "$RUNNER_TEMP/yarnrc.XXXXXX")
+          cp .yarnrc.yml "$YARNRC_BACKUP"
+          echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
+          : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
+          : # key); keep every other line untouched.
+          YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          : # Replace with mv instead of writing into the file, so a committed symlink cannot
+          : # redirect the write (the .npmrc generation pattern).
+          rm -f .yarnrc.yml
+          mv "$YARNRC_TMP" .yarnrc.yml
       # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
       # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
       # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
@@ -179,6 +207,15 @@ jobs:
           fi
         env:
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # always(): the original .yarnrc.yml must come back even when the credentialed
+      # install fails, both for the tokenless lifecycle replay below and so the sanitized
+      # file can never be committed by later steps or outlive the job on persistent
+      # self-hosted workspaces (YARNRC_BACKUP is only set when the step above sanitized).
+      - if: ${{ always() && env.YARNRC_BACKUP }}
+        name: Restore the original .yarnrc.yml
+        run: |
+          rm -f .yarnrc.yml
+          mv "$YARNRC_BACKUP" .yarnrc.yml
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
       # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -171,9 +171,9 @@ jobs:
           cp .yarnrc.yml "$YARNRC_BACKUP"
           echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
           : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
-          : # key); keep every other line untouched.
+          : # key; column-0 comments do not end the block); keep every other line untouched.
           YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
-          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]#]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
           : # Replace with mv instead of writing into the file, so a committed symlink cannot
           : # redirect the write (the .npmrc generation pattern).
           rm -f .yarnrc.yml

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,8 +10,6 @@ on:
       FNOX_AGE_KEY:
         description: age secret key to decrypt fnox.toml secrets
         required: false
-      GH_PKG_READ_TOKEN:
-        required: false
       VERDACCIO_TOKEN:
         description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
@@ -180,7 +178,6 @@ jobs:
             }
           fi
         env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
@@ -207,8 +204,6 @@ jobs:
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
             }
           fi
-        env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - name: Fix code
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,6 +337,34 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # Yarn Berry loads `.yarnrc.yml` plugins during every yarn command, including the
+      # credentialed install below, so a repository-committed plugin is config-driven code
+      # execution that can read the step-scoped VERDACCIO_TOKEN (#453). Strip the top-level
+      # `plugins:` block for the credentialed install only and restore the original file
+      # right after it, so plugins still apply to the tokenless lifecycle replay. Residual
+      # risk (out of scope here): the committed yarnPath release in .yarn/releases/ also
+      # executes during the credentialed install.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' && steps.env-info.outputs.runner != 'bun' && steps.env-info.outputs.skip-scripts-option != '--ignore-scripts' }}
+        name: Remove plugins from .yarnrc.yml for the credentialed install
+        run: |
+          if [[ ! -f .yarnrc.yml ]]; then exit 0; fi
+          : # Recover the committed content a crashed previous run may have left sanitized
+          : # (the always() restore cannot run when the runner dies, and persistent
+          : # self-hosted workspaces keep the worktree between runs).
+          if git ls-files --error-unmatch -- .yarnrc.yml > /dev/null 2>&1; then
+            git checkout -- .yarnrc.yml 2> /dev/null || true
+          fi
+          YARNRC_BACKUP=$(mktemp "$RUNNER_TEMP/yarnrc.XXXXXX")
+          cp .yarnrc.yml "$YARNRC_BACKUP"
+          echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
+          : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
+          : # key); keep every other line untouched.
+          YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          : # Replace with mv instead of writing into the file, so a committed symlink cannot
+          : # redirect the write (the .npmrc generation pattern).
+          rm -f .yarnrc.yml
+          mv "$YARNRC_TMP" .yarnrc.yml
       # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
       # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
       # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
@@ -366,6 +394,15 @@ jobs:
           fi
         env:
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # always(): the original .yarnrc.yml must come back even when the credentialed
+      # install fails, both for the tokenless lifecycle replay below and so the sanitized
+      # file can never be committed by later steps or outlive the job on persistent
+      # self-hosted workspaces (YARNRC_BACKUP is only set when the step above sanitized).
+      - if: ${{ always() && env.YARNRC_BACKUP }}
+        name: Restore the original .yarnrc.yml
+        run: |
+          rm -f .yarnrc.yml
+          mv "$YARNRC_BACKUP" .yarnrc.yml
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
       # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -358,9 +358,9 @@ jobs:
           cp .yarnrc.yml "$YARNRC_BACKUP"
           echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
           : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
-          : # key); keep every other line untouched.
+          : # key; column-0 comments do not end the block); keep every other line untouched.
           YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
-          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]#]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
           : # Replace with mv instead of writing into the file, so a committed symlink cannot
           : # redirect the write (the .npmrc generation pattern).
           rm -f .yarnrc.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,8 +89,6 @@ on:
         required: false
       GH_TOKEN:
         required: false
-      GH_PKG_READ_TOKEN:
-        required: false
       RAILWAY_API_TOKEN:
         required: false
       VERDACCIO_TOKEN:
@@ -367,7 +365,6 @@ jobs:
             }
           fi
         env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
@@ -394,8 +391,6 @@ jobs:
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
             }
           fi
-        env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - if: ${{ env.HAS_GCP_SA_KEY_JSON_FOR_FIREBASE == 'true' }}
         name: Create credential file for Firebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,9 +215,9 @@ jobs:
           cp .yarnrc.yml "$YARNRC_BACKUP"
           echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
           : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
-          : # key); keep every other line untouched.
+          : # key; column-0 comments do not end the block); keep every other line untouched.
           YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
-          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]#]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
           : # Replace with mv instead of writing into the file, so a committed symlink cannot
           : # redirect the write (the .npmrc generation pattern).
           rm -f .yarnrc.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,34 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # Yarn Berry loads `.yarnrc.yml` plugins during every yarn command, including the
+      # credentialed install below, so a repository-committed plugin is config-driven code
+      # execution that can read the step-scoped VERDACCIO_TOKEN (#453). Strip the top-level
+      # `plugins:` block for the credentialed install only and restore the original file
+      # right after it, so plugins still apply to the tokenless lifecycle replay. Residual
+      # risk (out of scope here): the committed yarnPath release in .yarn/releases/ also
+      # executes during the credentialed install.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' && steps.env-info.outputs.runner != 'bun' && steps.env-info.outputs.skip-scripts-option != '--ignore-scripts' }}
+        name: Remove plugins from .yarnrc.yml for the credentialed install
+        run: |
+          if [[ ! -f .yarnrc.yml ]]; then exit 0; fi
+          : # Recover the committed content a crashed previous run may have left sanitized
+          : # (the always() restore cannot run when the runner dies, and persistent
+          : # self-hosted workspaces keep the worktree between runs).
+          if git ls-files --error-unmatch -- .yarnrc.yml > /dev/null 2>&1; then
+            git checkout -- .yarnrc.yml 2> /dev/null || true
+          fi
+          YARNRC_BACKUP=$(mktemp "$RUNNER_TEMP/yarnrc.XXXXXX")
+          cp .yarnrc.yml "$YARNRC_BACKUP"
+          echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
+          : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
+          : # key); keep every other line untouched.
+          YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          : # Replace with mv instead of writing into the file, so a committed symlink cannot
+          : # redirect the write (the .npmrc generation pattern).
+          rm -f .yarnrc.yml
+          mv "$YARNRC_TMP" .yarnrc.yml
       # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
       # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
       # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
@@ -223,6 +251,15 @@ jobs:
           fi
         env:
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # always(): the original .yarnrc.yml must come back even when the credentialed
+      # install fails, both for the tokenless lifecycle replay below and so the sanitized
+      # file can never be committed by later steps or outlive the job on persistent
+      # self-hosted workspaces (YARNRC_BACKUP is only set when the step above sanitized).
+      - if: ${{ always() && env.YARNRC_BACKUP }}
+        name: Restore the original .yarnrc.yml
+        run: |
+          rm -f .yarnrc.yml
+          mv "$YARNRC_BACKUP" .yarnrc.yml
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
       # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,6 @@ on:
       VERDACCIO_TOKEN:
         description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
-      GH_PACKAGES_TOKEN:
-        required: false
-      GH_PKG_READ_TOKEN:
-        required: false
 
 jobs:
   release:
@@ -226,7 +222,6 @@ jobs:
             }
           fi
         env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
@@ -253,8 +248,6 @@ jobs:
               ${{ steps.env-info.outputs.runner }} install ${{ steps.env-info.outputs.skip-scripts-option }}
             }
           fi
-        env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
@@ -346,7 +339,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           # The release script's npm invocations expand ${VERDACCIO_TOKEN} from the generated .npmrc.
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
-          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
           HUSKY: 0
           LEFTHOOK: 0
 

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -233,6 +233,34 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # Yarn Berry loads `.yarnrc.yml` plugins during every yarn command, including the
+      # credentialed install below, so a repository-committed plugin is config-driven code
+      # execution that can read the step-scoped VERDACCIO_TOKEN (#453). Strip the top-level
+      # `plugins:` block for the credentialed install only and restore the original file
+      # right after it, so plugins still apply to the tokenless lifecycle replay. Residual
+      # risk (out of scope here): the committed yarnPath release in .yarn/releases/ also
+      # executes during the credentialed install.
+      - if: ${{ env.HAS_VERDACCIO_TOKEN == 'true' && steps.env-info.outputs.runner != 'bun' && steps.env-info.outputs.skip-scripts-option != '--ignore-scripts' }}
+        name: Remove plugins from .yarnrc.yml for the credentialed install
+        run: |
+          if [[ ! -f .yarnrc.yml ]]; then exit 0; fi
+          : # Recover the committed content a crashed previous run may have left sanitized
+          : # (the always() restore cannot run when the runner dies, and persistent
+          : # self-hosted workspaces keep the worktree between runs).
+          if git ls-files --error-unmatch -- .yarnrc.yml > /dev/null 2>&1; then
+            git checkout -- .yarnrc.yml 2> /dev/null || true
+          fi
+          YARNRC_BACKUP=$(mktemp "$RUNNER_TEMP/yarnrc.XXXXXX")
+          cp .yarnrc.yml "$YARNRC_BACKUP"
+          echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
+          : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
+          : # key); keep every other line untouched.
+          YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          : # Replace with mv instead of writing into the file, so a committed symlink cannot
+          : # redirect the write (the .npmrc generation pattern).
+          rm -f .yarnrc.yml
+          mv "$YARNRC_TMP" .yarnrc.yml
       # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
       # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
       # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
@@ -252,6 +280,15 @@ jobs:
           fi
         env:
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # always(): the original .yarnrc.yml must come back even when the credentialed
+      # install fails, both for the tokenless lifecycle replay below and so the sanitized
+      # file can never be committed by later steps or outlive the job on persistent
+      # self-hosted workspaces (YARNRC_BACKUP is only set when the step above sanitized).
+      - if: ${{ always() && env.YARNRC_BACKUP }}
+        name: Restore the original .yarnrc.yml
+        run: |
+          rm -f .yarnrc.yml
+          mv "$YARNRC_BACKUP" .yarnrc.yml
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
       # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -254,9 +254,9 @@ jobs:
           cp .yarnrc.yml "$YARNRC_BACKUP"
           echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
           : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
-          : # key); keep every other line untouched.
+          : # key; column-0 comments do not end the block); keep every other line untouched.
           YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
-          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]#]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
           : # Replace with mv instead of writing into the file, so a committed symlink cannot
           : # redirect the write (the .npmrc generation pattern).
           rm -f .yarnrc.yml

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -73,8 +73,6 @@ on:
         required: false
       GH_TOKEN:
         required: false
-      GH_PKG_READ_TOKEN:
-        required: false
       VERDACCIO_TOKEN:
         description: auth token for the private Verdaccio registry (used to generate .npmrc)
         required: false
@@ -253,7 +251,6 @@ jobs:
             ${{ steps.env-info.outputs.runner }} install
           fi
         env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
@@ -277,8 +274,6 @@ jobs:
             fi
             ${{ steps.env-info.outputs.runner }} install
           fi
-        env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
 
       - name: Run "common/ci-setup" npm script if exists
         run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -333,9 +333,9 @@ jobs:
           cp .yarnrc.yml "$YARNRC_BACKUP"
           echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
           : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
-          : # key); keep every other line untouched.
+          : # key; column-0 comments do not end the block); keep every other line untouched.
           YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
-          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]#]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
           : # Replace with mv instead of writing into the file, so a committed symlink cannot
           : # redirect the write (the .npmrc generation pattern).
           rm -f .yarnrc.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,6 +312,34 @@ jobs:
               echo '/.npmrc' >> .git/info/exclude
             fi
           fi
+      # Yarn Berry loads `.yarnrc.yml` plugins during every yarn command, including the
+      # credentialed install below, so a repository-committed plugin is config-driven code
+      # execution that can read the step-scoped VERDACCIO_TOKEN (#453). Strip the top-level
+      # `plugins:` block for the credentialed install only and restore the original file
+      # right after it, so plugins still apply to the tokenless lifecycle replay. Residual
+      # risk (out of scope here): the committed yarnPath release in .yarn/releases/ also
+      # executes during the credentialed install.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' && env.HAS_VERDACCIO_TOKEN == 'true' && steps.env-info.outputs.runner != 'bun' && steps.env-info.outputs.skip-scripts-option != '--ignore-scripts' }}
+        name: Remove plugins from .yarnrc.yml for the credentialed install
+        run: |
+          if [[ ! -f .yarnrc.yml ]]; then exit 0; fi
+          : # Recover the committed content a crashed previous run may have left sanitized
+          : # (the always() restore cannot run when the runner dies, and persistent
+          : # self-hosted workspaces keep the worktree between runs).
+          if git ls-files --error-unmatch -- .yarnrc.yml > /dev/null 2>&1; then
+            git checkout -- .yarnrc.yml 2> /dev/null || true
+          fi
+          YARNRC_BACKUP=$(mktemp "$RUNNER_TEMP/yarnrc.XXXXXX")
+          cp .yarnrc.yml "$YARNRC_BACKUP"
+          echo "YARNRC_BACKUP=$YARNRC_BACKUP" >> "$GITHUB_ENV"
+          : # Drop the top-level `plugins:` block (from `plugins:` up to the next top-level
+          : # key); keep every other line untouched.
+          YARNRC_TMP=$(mktemp "$RUNNER_TEMP/yarnrc-sanitized.XXXXXX")
+          awk '/^plugins:/ { skip = 1; next } skip && /^[^[:space:]]/ { skip = 0 } !skip' "$YARNRC_BACKUP" > "$YARNRC_TMP"
+          : # Replace with mv instead of writing into the file, so a committed symlink cannot
+          : # redirect the write (the .npmrc generation pattern).
+          rm -f .yarnrc.yml
+          mv "$YARNRC_TMP" .yarnrc.yml
       # With a Verdaccio token, resolve and download with lifecycle scripts disabled so
       # repository- or dependency-defined preinstall/postinstall can never read the step-scoped
       # VERDACCIO_TOKEN (#449); the tokenless step below replays the skipped scripts.
@@ -341,6 +369,15 @@ jobs:
           fi
         env:
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+      # always(): the original .yarnrc.yml must come back even when the credentialed
+      # install fails, both for the tokenless lifecycle replay below and so the sanitized
+      # file can never be committed by later steps or outlive the job on persistent
+      # self-hosted workspaces (YARNRC_BACKUP is only set when the step above sanitized).
+      - if: ${{ always() && env.YARNRC_BACKUP }}
+        name: Restore the original .yarnrc.yml
+        run: |
+          rm -f .yarnrc.yml
+          mv "$YARNRC_BACKUP" .yarnrc.yml
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
       # .npmrc/.yarnrc.yml expanding to '' instead of erroring). Every package is already in the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ on:
       FNOX_AGE_KEY:
         description: age secret key to decrypt fnox.toml secrets
         required: false
-      GH_PKG_READ_TOKEN:
-        required: false
       GH_TOKEN:
         required: true
       VERDACCIO_TOKEN:
@@ -342,7 +340,6 @@ jobs:
             }
           fi
         env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
       # Replay the lifecycle scripts the credentialed install skipped, in an environment without
       # VERDACCIO_TOKEN (the job-level empty value keeps ${VERDACCIO_TOKEN} references in
@@ -369,8 +366,6 @@ jobs:
               ${{ steps.env-info.outputs.runner }} install --no-immutable ${{ steps.env-info.outputs.skip-scripts-option }}
             }
           fi
-        env:
-          GH_PKG_READ_TOKEN: ${{ secrets.GH_PKG_READ_TOKEN }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run "common/ci-setup" npm script if exists
         run: if grep -q '"common/ci-setup":' package.json; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi


### PR DESCRIPTION
## Summary

Two hardening fixes for the reusable workflows, follow-ups to #449/#450.

### Remove `GH_PKG_READ_TOKEN` and `GH_PACKAGES_TOKEN` (Closes #452)

An org-wide audit found no repository in WillBooster or WillBoosterLab that references the GitHub Packages npm registry (npm.pkg.github.com) in any package-manager config, and no config that expands `${GH_PKG_READ_TOKEN}` — the secret was consumed by no org repository. Rather than narrowing it to the credentialed install step, the secret declaration and every env passthrough are removed from `autofix.yml`, `deploy.yml`, `release.yml`, `run-script.yml`, and `test.yml`.

A code search for `GH_PACKAGES_TOKEN` across both orgs matched only reusable-workflows itself (and the WillBoosterLab mirror), so its declaration and the Release-step passthrough in `release.yml` are removed as well.

The only caller passing `GH_PKG_READ_TOKEN` is WillBooster/openclaw-railway's autofix caller (mapping `secrets.VERDACCIO_TOKEN` to it — dead config); a companion PR removes that line so the caller keeps compiling.

### Strip `.yarnrc.yml` plugins during the credentialed install (Closes #453)

Verified empirically: a `.yarnrc.yml`-declared plugin's module top-level code executes during `yarn install` on Yarn Berry 4 and can read tokens from the environment, even with lifecycle scripts disabled — a repository-committed plugin is a config-driven code-execution vector for the step-scoped `VERDACCIO_TOKEN`.

Mitigation (defense-in-depth; no Berry repo currently references `${VERDACCIO_TOKEN}` in `.yarnrc.yml`): when a Verdaccio token is present and the repo is Yarn Berry (yarn runner without `--ignore-scripts`), a step before the credentialed install backs up `.yarnrc.yml` and removes its top-level `plugins:` block (everything else byte-identical); an `always()` step right after the install restores the original before the tokenless lifecycle replay, so plugin behavior (e.g. the org's auto-install plugin) is unaffected. The sanitize step also recovers state a crashed previous run may have left on persistent self-hosted workspaces, mirroring the `.npmrc` generation pattern. Residual risk noted in comments: the committed yarnPath release file also executes during the credentialed install (out of scope).

Validation: all workflow files parse as YAML; `@action-validator/cli` passes on all modified workflows except a pre-existing false positive in `release.yml` (`concurrency.queue`, fails on `main` too). The sanitizer awk was verified end-to-end in a scratch Berry project (plugin runs before sanitizing, does not run after).

Closes #452
Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
