### PR TITLE
fix: step-scope FNOX_AGE_KEY so dependency lifecycle scripts cannot read the age identity

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,8 +23,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (!inputs.target_organization || github.repository_owner == inputs.target_organization) }}
     runs-on: self-hosted
     env:
-      # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
-      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      # FNOX_AGE_KEY is deliberately NOT job-wide: like VERDACCIO_TOKEN, it is provided
+      # step-scoped only to the steps that actually run fnox (the check-fnox-secrets action and
+      # the "Fix code" step), so dependency lifecycle scripts run by the installs and the
+      # lifecycle replay below can never read the long-lived age identity (#458).
       # Non-secret signal for the `if:` gates below; the VERDACCIO_TOKEN secret itself is
       # provided step-scoped only to the steps whose package-manager invocations expand it
       # from the generated .npmrc.
@@ -85,6 +87,9 @@ jobs:
         uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
         with:
           mode: warning
+        env:
+          # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212
@@ -267,6 +272,9 @@ jobs:
             git push origin "HEAD:refs/heads/$HEAD_REF" --no-verify
           fi
         env:
+          # Consumer gen-code/cleanup/build scripts load env vars through wb/fnox (step-scoped;
+          # see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           HEAD_REF: ${{ github.head_ref }}
           HUSKY: 0
           LEFTHOOK: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,8 +104,10 @@ jobs:
       # constants
       PYTHON_VERSION: 3.13.9
       # arguments
-      # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
-      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      # FNOX_AGE_KEY is deliberately NOT job-wide: like VERDACCIO_TOKEN, it is provided
+      # step-scoped only to the steps that actually run fnox (the check-fnox-secrets action and
+      # the consumer script steps), so dependency lifecycle scripts run by the installs and the
+      # lifecycle replay below can never read the long-lived age identity (#458).
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_FLY_API_TOKEN: ${{ !!secrets.FLY_API_TOKEN }}
@@ -208,6 +210,9 @@ jobs:
         uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
         with:
           working_directory: ${{ inputs.working_directory }}
+        env:
+          # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - if: ${{ steps.check-gcloud.outputs.require-gcloud }}
         name: Install gcloud with mise
         uses: nick-fields/retry@dd56f1ca8ca991e2385c18ab6dd36ea7f9fdb55f
@@ -479,6 +484,8 @@ jobs:
       - name: Run "common/ci-setup" npm script if exists
         run: bash "$RUNNER_TEMP/run-ci-setup.sh" common/ci-setup
         env:
+          # Consumer hooks load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           # Consumer hooks may install private packages (e.g. `bunx @willbooster-private/...`),
           # which expand ${VERDACCIO_TOKEN} from the generated .npmrc at run time.
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
@@ -498,6 +505,9 @@ jobs:
             ${{ steps.env-info.outputs.runner }} run ${{ inputs.deploy_command || 'deploy' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # The deploy/ci-setup hook and the deploy script load env vars through wb/fnox
+          # (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GCP_SA_KEY_JSON: ${{ secrets.GCP_SA_KEY_JSON }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,10 @@ jobs:
       FORCE_COLOR: 3
       NODE_OPTIONS: --max-old-space-size=4096
       # arguments
-      # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
-      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      # FNOX_AGE_KEY is deliberately NOT job-wide: like VERDACCIO_TOKEN, it is provided
+      # step-scoped only to the steps that actually run fnox (the check-fnox-secrets action and
+      # the consumer script steps), so dependency lifecycle scripts run by the installs and the
+      # lifecycle replay below can never read the long-lived age identity (#458).
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       # Non-secret signal for the `if:` gates below; the VERDACCIO_TOKEN secret itself is
@@ -116,6 +118,9 @@ jobs:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
       - name: Ensure fnox secrets are resolvable
         uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
+        env:
+          # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - name: Show environment information
         id: env-info
         # https://stackoverflow.com/a/677212
@@ -288,6 +293,10 @@ jobs:
       - if: ${{ !inputs.skip_build }}
         name: Build
         run: if [[ "$(cat package.json)" == *'"build":'* ]]; then ${{ steps.env-info.outputs.runner }} run build; fi
+        env:
+          # The consumer build script loads env vars through wb/fnox (step-scoped; see the fnox
+          # check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       # After waiting in the concurrency queue, a run can be older than the branch head a
       # later run already released from; releasing from the stale checkout could publish a
       # lower version after a higher one. GitHub does not guarantee queue ordering, so skip
@@ -371,6 +380,11 @@ jobs:
             node node_modules/semantic-release/bin/semantic-release.js
           fi
         env:
+          # The consumer release script loads env vars through wb/fnox (step-scoped; see the
+          # fnox check step above). Known residual risk, same as VERDACCIO_TOKEN here:
+          # `wb release` clean-reinstalls with lifecycle scripts enabled while this step's
+          # credentials are in the environment (shared#1003).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write
           # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -83,8 +83,10 @@ jobs:
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || (inputs.cpu_arch && fromJSON(format('["self-hosted", "{0}", "{1}"]', inputs.ci_label, inputs.cpu_arch))) || fromJSON(format('["self-hosted", "{0}"]', inputs.ci_label)) }}
     env:
       FORCE_COLOR: 3
-      # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
-      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      # FNOX_AGE_KEY is deliberately NOT job-wide: like VERDACCIO_TOKEN, it is provided
+      # step-scoped only to the steps that actually run fnox (the check-fnox-secrets action and
+      # the consumer script steps), so dependency lifecycle scripts run by the installs and the
+      # lifecycle replay below can never read the long-lived age identity (#458).
       HAS_DISCORD_WEBHOOK_URL: ${{ !!secrets.DISCORD_WEBHOOK_URL }}
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_FILE_CONTENT_1: ${{ !!secrets.FILE_CONTENT_1 }}
@@ -158,6 +160,9 @@ jobs:
           cache: ${{ toJSON(runner.environment != 'self-hosted') }}
       - name: Ensure fnox secrets are resolvable
         uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
+        env:
+          # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - name: Show environment information
         id: env-info
         run: |
@@ -315,6 +320,8 @@ jobs:
       - name: Run "common/ci-setup" npm script if exists
         run: if [[ "$(cat package.json)" == *'"common/ci-setup":'* ]]; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
         env:
+          # Consumer hooks load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           # Consumer hooks may install private packages (e.g. `bunx @willbooster-private/...`),
           # which expand ${VERDACCIO_TOKEN} from the generated .npmrc at run time.
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
@@ -331,6 +338,9 @@ jobs:
         env:
           COMMAND: ${{ inputs.command }}
           COMMAND_ARGS: ${{ inputs.command_args }}
+          # The consumer script loads env vars through wb/fnox (step-scoped; see the fnox check
+          # step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           # Consumer maintenance scripts may install private packages (e.g. `bunx
           # @willbooster-private/...`), which expand ${VERDACCIO_TOKEN} from the generated .npmrc.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,10 @@ jobs:
       FORCE_COLOR: 3
       NODE_OPTIONS: --max-old-space-size=4096
       # arguments
-      # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
-      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      # FNOX_AGE_KEY is deliberately NOT job-wide: like VERDACCIO_TOKEN, it is provided
+      # step-scoped only to the steps that actually run fnox (the check-fnox-secrets action and
+      # the consumer script steps), so dependency lifecycle scripts run by the installs and the
+      # lifecycle replay below can never read the long-lived age identity (#458).
       HAS_DOT_ENV: ${{ !!secrets.DOT_ENV }}
       HAS_TEST_COMMAND: ${{ !!inputs.custom_test_command }}
       # Non-secret signal for the `if:` gates below; the VERDACCIO_TOKEN secret itself is
@@ -208,6 +210,9 @@ jobs:
         uses: WillBooster/reusable-workflows/.github/actions/check-fnox-secrets@main
         with:
           mode: warning
+        env:
+          # Empty when the caller does not provide the secret, which keeps fnox-less consumers unaffected.
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Show environment information
         id: env-info
@@ -406,6 +411,9 @@ jobs:
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run "common/ci-setup" npm script if exists
         run: if grep -q '"common/ci-setup":' package.json; then ${{ steps.env-info.outputs.runner }} run common/ci-setup; fi
+        env:
+          # Consumer scripts load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run "test/ci-setup" npm script if exists
         run: |
@@ -414,6 +422,9 @@ jobs:
           elif grep -q '"playwright"' package.json; then
             ${{ steps.env-info.outputs.runner }} playwright install
           fi
+        env:
+          # Consumer scripts load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Fix code
         run: |
@@ -459,6 +470,8 @@ jobs:
           fi
         env:
           DOT_ENV_PATH: ${{ inputs.dot_env_path }}
+          # Consumer scripts load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           HEAD_REF: ${{ github.head_ref || github.ref_name }}
       # Typecheck must be executed after `gen-code`
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
@@ -469,6 +482,9 @@ jobs:
             rm -Rf .next
             ${{ steps.env-info.outputs.runner }} run typecheck
           fi
+        env:
+          # Consumer scripts load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Test
         run: |
@@ -480,6 +496,8 @@ jobs:
             ${{ steps.env-info.outputs.runner }} run test
           fi
         env:
+          # Consumer scripts load env vars through wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Run lint-staged
@@ -491,6 +509,10 @@ jobs:
             done
             ${{ steps.env-info.outputs.runner }} run lint-staged --allow-empty
           fi
+        env:
+          # lint-staged entries are consumer-defined commands that may load env vars through
+          # wb/fnox (step-scoped; see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
       # Note: `env.GITHUB_TOKEN` here reads this step's own step-level env (the runner merges a
       # step's `env:` into the `env` context before evaluating its `if:`); consumer runs show the
       # step executing, so this gate is live, not dead.
@@ -509,6 +531,9 @@ jobs:
             fi
           fi
         env:
+          # The consumer release-test script may load env vars through wb/fnox (step-scoped;
+          # see the fnox check step above).
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}


### PR DESCRIPTION
Closes #458

## Customer Summary

- No consumer-visible behavior change: repositories calling the reusable workflows keep working unchanged, and their scripts (tests, builds, deploys, releases, maintenance jobs) still receive `FNOX_AGE_KEY` exactly as before.
- Security hardening: third-party dependency install scripts can no longer read the long-lived age key that decrypts every committed fnox secret, closing the exfiltration path described in #458.

## Technical Summary

- Applies the VERDACCIO_TOKEN step-scoping discipline from #448/#450 to `FNOX_AGE_KEY` across the five install-capable workflows (`test.yml`, `release.yml`, `deploy.yml`, `run-script.yml`, `autofix.yml`).
- `FNOX_AGE_KEY` is removed from the job-level `env` (a comment at the former location documents the rationale) and passed step-scoped only to the steps that actually run fnox:
  - the `check-fnox-secrets` action step in every workflow (step-level `env` on a `uses:` step propagates into composite action steps — actions/runner#557);
  - the consumer script steps whose commands load env vars through wb/fnox: `common/ci-setup`, `test/ci-setup`, Fix code, typecheck, Test, lint-staged, and the release-test dry run (test.yml); Build and Release (release.yml); `common/ci-setup` and Deploy (deploy.yml); `common/ci-setup` and Run script (run-script.yml); Fix code (autofix.yml).
- Dependency installs and the lifecycle-script replay run without the key, including the plain `bun install` path that executes `trustedDependencies` scripts.
- No `HAS_FNOX_AGE_KEY` signal was added: no `if:` gate reads the key's presence — `check-fnox-secrets` validates by actual strict-mode resolution, and fnox-less consumers are unaffected by an empty/undefined key.
- release.yml's Release step keeps the key with a comment noting the shared#1003 residual risk (`wb release` clean-reinstalls with lifecycle scripts enabled while release credentials are in the environment) — the same residual as VERDACCIO_TOKEN there.

## Why

- Since #448/#450 the workflows step-scope `VERDACCIO_TOKEN`, but the lifecycle-script replay (and any plain `bun install`) still inherited the job-wide `FNOX_AGE_KEY`, so a compromised dependency lifecycle script could exfiltrate the age identity even though the registry credential was scrubbed.
- Step-scoping mirrors the established precedent in this repository, keeping the isolation model uniform for both secrets.

## Testing

- `bunx @action-validator/cli` on all five workflows: test/deploy/run-script/autofix pass; release.yml reports only the pre-existing false positive on `concurrency.queue` (identical error count on `main`) and parses cleanly as YAML (`Bun.YAML.parse`).
- `grep` confirms no job-level `FNOX_AGE_KEY` remains and the install/replay steps receive no key.
- Multi-agent review (Codex, Claude Code, Antigravity): all returned "no concern"; composite-action env propagation confirmed against actions/runner#557.
