### PR TITLE
fix: tolerate bun lifecycle-replay failures like the yarn branch already does

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -419,7 +419,14 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install
+            bun install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
+              : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              rm -rf node_modules
+              bun install --ignore-scripts
+            }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
               : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,14 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install
+            bun install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
+              : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              rm -rf node_modules
+              bun install --ignore-scripts
+            }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
               : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -394,7 +394,14 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install
+            bun install || {
+              : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
+              : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
+              : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
+              echo "::warning::Lifecycle scripts failed; completing the install without them"
+              rm -rf node_modules
+              bun install --ignore-scripts
+            }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then
               : # yarn1 reports "Already up-to-date" and skips scripts unless node_modules is


### PR DESCRIPTION
## Problem

Since #459 step-scoped `FNOX_AGE_KEY` away from the keyless "Run dependency lifecycle scripts without registry credentials" step, any **bun + fnox** repository whose `postinstall` runs `wb gen-code` with a non-empty `.env.example` hard-fails that step: `wb`'s env loader sees the fnox source exists but cannot decrypt, so its `--check-env` validation throws `Missing environment variables in []: [...]`, and bun exits 1.

First observed failure: noo-zero Release run https://github.com/WillBooster/noo-zero/actions/runs/29705911343 (blocks today's releases of noo-zero, draft-booster, moti-ai, agentic-workflows-dashboard, agent-challenges, pkg-preflight).

## Fix

The yarn branch of the replay already tolerates lifecycle failures ("Keep postinstall failures tolerated (consumers rely on it)") by falling back to an `--ignore-scripts` install. Give the bun branch the same fallback in `release.yml`, `deploy.yml`, and `test.yml`. `FNOX_AGE_KEY` stays out of the step, preserving #459's security property.

`run-script.yml`'s replay has no tolerance in either branch today; left unchanged for consistency with its own policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
