### PR TITLE
fix: remove unused `version` input from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,6 @@ on:
       target_organization:
         required: false
         type: string
-      version:
-        required: false
-        type: string
       working_directory:
         # Deploy target directory (e.g. packages/server for a monorepo Worker). The "common/ci-setup"
         # and "deploy/ci-setup" hooks are looked up here first and in the repository root as a


### PR DESCRIPTION
## Summary

- Remove the `version` input from `.github/workflows/deploy.yml`: no caller in WillBooster / WillBoosterLab passes it, and the workflow derives `WB_VERSION` from `git describe` instead.

## Verification

- Searched both orgs (`gh search code` + local ghq clones) for callers passing `version:` to `deploy.yml@main` — none exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
