### PR TITLE
fix: point Renovate at the shared preset's current filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "sort-package-json",
     "pre-push": "echo 'start pre-push'; sleep 60; bun run sync",
     "prepare": "lefthook install || true",
-    "sync": "one-way-git-sync -v -i node_modules -i renovate.json -d git@github.com:WillBoosterLab/reusable-workflows.git",
+    "sync": "one-way-git-sync -v -i node_modules -i renovate.jsonc -d git@github.com:WillBoosterLab/reusable-workflows.git",
     "sync-force": "bun run sync --force",
     "verify": "bun node_modules/@willbooster/wb/bin/index.js verify",
     "verify-full": "bun node_modules/@willbooster/wb/bin/index.js verify --full"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>WillBooster/willbooster-configs:renovate.json5"
-  ]
-}

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>WillBooster/willbooster-configs:renovate.jsonc"]
+}


### PR DESCRIPTION
## Problem

Renovate has raised no PRs on this repository since `WillBooster/willbooster-configs` renamed `renovate.json5` → `renovate.jsonc`. A *named* preset is resolved by exact filename, so `github>WillBooster/willbooster-configs:renovate.json5` 404s and Renovate aborts the whole config.

This is not a local quirk — ~26 repositories across both orgs still point at the old filename and have silently dead Renovate. They are being fixed by running `wbfy`, which already migrates the legacy reference; this repository is fixed directly so its own Renovate resumes immediately.

## Changes

- `renovate.json` → `renovate.jsonc`, extending `…willbooster-configs:renovate.jsonc`. The rename matches what wbfy generates, so wbfy stays idempotent here.
- `package.json`'s `sync` script excluded the config from the WillBoosterLab mirror by exact name (`-i renovate.json`). Renamed to `-i renovate.jsonc` — without this, the rename would silently start mirroring this repository's Renovate config to the Lab fork.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
