### PR TITLE
fix: reject fork PRs before the node-version detection checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,15 @@ jobs:
     outputs:
       json: ${{ steps.detect-node-version-matrix.outputs.json }}
     steps:
+      # Same rejection as the test job below, and for the same reason: this job checks out the
+      # pull-request merge ref and its `npx -y semver` fallback executes a package resolved via
+      # the checked-out workspace's .npmrc, so fork-controlled code could otherwise run on a
+      # persistent self-hosted runner before the test job's rejection fires.
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        name: Reject fork pull requests on self-hosted runners
+        run: |
+          echo '::error::Fork pull requests are not supported on persistent self-hosted runners.'
+          exit 1
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Clear stale skip-worktree bits left by a crashed previous run
         uses: WillBooster/reusable-workflows/.github/actions/clear-stale-skip-worktree@main


### PR DESCRIPTION
## Summary

Follow-up to #466's fork-PR rejection: the `detect-node-version-matrix` job in `test.yml` checks out the pull-request merge ref and its `npx -y semver` fallback executes a package resolved through the checked-out workspace's `.npmrc` — so on a persistent self-hosted runner (private repo), a fork PR could delete the Node version files and commit an `.npmrc` pointing `registry` at an attacker-controlled host, executing attacker code before the `test` job's rejection step fires. Add the same rejection step before this job's checkout (`pre` jobs perform no checkout and need none).

## Testing

- Workflow YAML parses cleanly; `bun verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
