### PR TITLE
fix: publish public packages to npmjs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,6 +450,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write
           # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          # Takumi Guard is an install proxy, not a publish registry. publishConfig.registry
+          # still takes precedence for packages intentionally published elsewhere.
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
           # The release script's npm invocations expand these tokens from the generated .npmrc.
           TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}

--- a/test/unit/releaseRegistry.test.ts
+++ b/test/unit/releaseRegistry.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })));
+});
+
+describe('release workflow registry', () => {
+  test('publishes public packages to npmjs when Takumi Guard is enabled', async () => {
+    const workflow = Bun.YAML.parse(await Bun.file('.github/workflows/release.yml').text());
+    const releaseStep = workflow.jobs.release.steps.find((step: { name?: string }) => step.name === 'Release');
+
+    const temporaryRoot = join(process.cwd(), '.tmp');
+    await mkdir(temporaryRoot, { recursive: true });
+    const temporaryDirectory = await mkdtemp(join(temporaryRoot, 'release-registry-'));
+    temporaryDirectories.push(temporaryDirectory);
+    const npmrcPath = join(temporaryDirectory, '.npmrc');
+    await Bun.write(npmrcPath, 'registry=https://npm.flatt.tech/\n');
+
+    const childProcess = Bun.spawn(['npm', 'config', 'get', 'registry', '--userconfig', npmrcPath], {
+      env: {
+        ...Bun.env,
+        NPM_CONFIG_REGISTRY: releaseStep.env.NPM_CONFIG_REGISTRY,
+      },
+      stdout: 'pipe',
+    });
+
+    expect(await new Response(childProcess.stdout).text()).toBe('https://registry.npmjs.org/\n');
+    expect(await childProcess.exited).toBe(0);
+  });
+});


### PR DESCRIPTION
## Customer Summary

- Release workflows no longer try to publish public packages through Takumi Guard.
- Takumi Guard continues protecting dependency installation; private packages with an explicit publish registry remain unaffected.

## Technical Summary

- Set `NPM_CONFIG_REGISTRY=https://registry.npmjs.org/` only on the Release step.
- Keep `publishConfig.registry` authoritative for packages intentionally published to another registry.
- Add a regression test that resolves npm's effective registry from the real workflow configuration while a Takumi Guard `.npmrc` is present.

## Why

The generated install-time `.npmrc` sets Takumi Guard as the default registry. Semantic-release inherited that setting and attempted to publish `@willbooster/wb` to `npm.flatt.tech`, which rejects publish requests with HTTP 405.

## Testing

- `bun test test/unit/releaseRegistry.test.ts`
- `bun verify-full`
- Pull request CI passed
