### PR TITLE
fix: keep npm publishes off the Takumi Guard proxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,6 +448,12 @@ jobs:
           # credentials are in the environment (shared#1003).
           FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # PAT with contents:write
+          # Pin the DEFAULT publish registry back to npmjs: the generated .npmrc may point
+          # `registry=` at the Takumi Guard proxy, which is an install-side cache that rejects
+          # `npm publish` with 405; semantic-release's npm plugin resolves the registry as
+          # `publishConfig.registry || env.NPM_CONFIG_REGISTRY || rc(.npmrc)`, so packages
+          # publishing to Verdaccio (which declare publishConfig.registry) are unaffected.
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
           # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           # The release script's npm invocations expand these tokens from the generated .npmrc.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -608,6 +608,12 @@ jobs:
           # see the fnox check step above).
           FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Pin the DEFAULT publish registry back to npmjs: the generated .npmrc may point
+          # `registry=` at the Takumi Guard proxy, which is an install-side cache that rejects
+          # `npm publish` with 405; semantic-release's npm plugin resolves the registry as
+          # `publishConfig.registry || env.NPM_CONFIG_REGISTRY || rc(.npmrc)`, so packages
+          # publishing to Verdaccio (which declare publishConfig.registry) are unaffected.
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
           # semantic-release's npm plugin reads the NPM_TOKEN env var for registry auth.
           NPM_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           # The dry run's npm invocations expand these tokens from the generated .npmrc.


### PR DESCRIPTION
## Summary

WillBooster/shared's Release run [30050778519](https://github.com/WillBooster/shared/actions/runs/30050778519) failed after #466: with `TAKUMI_GUARD_TOKEN` set (and no `publishConfig.registry` on `@willbooster/wb`), semantic-release's npm plugin resolved the publish registry from the generated workspace `.npmrc` — now the Takumi Guard proxy — and `npm publish` failed with `405 Method Not Allowed - PUT https://npm.flatt.tech/@willbooster%2fwb`. The Guard proxy is an install-side cache; publishes must never route through it.

Fix: pin `NPM_CONFIG_REGISTRY=https://registry.npmjs.org/` on the two publish-performing steps (`release.yml`'s Release step and `test.yml`'s release-test dry run). Per `@semantic-release/npm`'s `get-registry.js`, resolution is `publishConfig.registry || env.NPM_CONFIG_REGISTRY || rc(.npmrc)`, so packages publishing to Verdaccio (which declare `publishConfig.registry` per org policy) are unaffected, and installs in all other steps keep routing through Guard.

Fallout note: run 30050778519 pushed the tag `@willbooster/wb@17.0.0` before failing to publish; the orphan tag is deleted separately so the next Release run re-releases 17.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
