### PR TITLE
feat: issue autofix App tokens via the OIDC token broker

### DIFF
--- a/.github/actions/broker-token/action.yml
+++ b/.github/actions/broker-token/action.yml
@@ -1,0 +1,56 @@
+name: Broker token
+description: >-
+  Exchanges the job's GitHub Actions OIDC ID token for a short-lived GitHub App installation token
+  issued by the WillBooster token broker. The broker verifies the ID token's job_workflow_ref
+  against a hard-coded policy and returns a token scoped to the calling repository only, with
+  contents:write only — so no App credential ever exists in GitHub Secrets. The calling workflow
+  must grant `permissions: id-token: write`.
+inputs:
+  identity:
+    description: Broker policy identity (`autofix` or `wbfy`).
+    required: true
+  broker_url:
+    description: Base URL of the token broker.
+    default: https://github-token-broker.willbooster-broker.workers.dev
+outputs:
+  token:
+    description: GitHub App installation token (1 hour, single repository, contents:write).
+    value: ${{ steps.exchange.outputs.token }}
+runs:
+  using: composite
+  steps:
+    - id: exchange
+      name: Exchange the OIDC ID token for an App token
+      shell: bash
+      env:
+        IDENTITY: ${{ inputs.identity }}
+        BROKER_URL: ${{ inputs.broker_url }}
+      run: |
+        : # ACTIONS_ID_TOKEN_REQUEST_URL only exists when the job may mint ID tokens.
+        if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+          echo '::error::OIDC is unavailable: the calling workflow must grant `permissions: id-token: write` to the job that uses this action.'
+          exit 1
+        fi
+        : # The URL is quoted as a whole and the audience is appended with `&`: the variable
+        : # already contains a query string, so `?` would produce a second query and a token
+        : # minted for the default audience, which the broker rejects.
+        ID_TOKEN="$(curl --fail --silent --show-error --retry 3 \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=willbooster-token-broker" | jq -r '.value')"
+        : # The broker replies with a bare status code on rejection; the reason is in its logs.
+        : # Failures here are fail-closed: autofix skips its commit and wbfy skips its push.
+        RESPONSE="$(curl --fail --silent --show-error --retry 3 \
+          -X POST "$BROKER_URL/token" \
+          -H "Authorization: Bearer $ID_TOKEN" \
+          -H 'Content-Type: application/json' \
+          --data "$(jq -n --arg identity "$IDENTITY" '{identity: $identity}')")" || {
+          echo "::error::The token broker rejected the request (identity: $IDENTITY). See the broker's Workers Logs for the reason."
+          exit 1
+        }
+        TOKEN="$(jq -r '.token // ""' <<< "$RESPONSE")"
+        if [[ -z "$TOKEN" ]]; then
+          echo '::error::The token broker returned no token.'
+          exit 1
+        fi
+        echo "::add-mask::$TOKEN"
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"

--- a/.github/actions/broker-token/action.yml
+++ b/.github/actions/broker-token/action.yml
@@ -34,6 +34,9 @@ runs:
         : # The URL is quoted as a whole and the audience is appended with `&`: the variable
         : # already contains a query string, so `?` would produce a second query and a token
         : # minted for the default audience, which the broker rejects.
+        : # No extra validation of ID_TOKEN is needed: `shell: bash` runs with `-eo pipefail`, so
+        : # a non-2xx OIDC response aborts here via --fail, and any unusable value (the endpoint
+        : # never returns 2xx without .value) just fails closed at the broker with a 401.
         ID_TOKEN="$(curl --fail --silent --show-error --retry 3 \
           -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
           "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=willbooster-token-broker" | jq -r '.value')"

--- a/.github/workflows/autofix-apply.yml
+++ b/.github/workflows/autofix-apply.yml
@@ -110,3 +110,14 @@ jobs:
           # Derived from the event, never from the patch, so the patch cannot redirect the write.
           branch: ${{ github.event.workflow_run.head_branch }}
           expected_head_oid: ${{ github.event.workflow_run.head_sha }}
+
+      # The retired create-github-app-token action revoked its token in a post step; a composite
+      # action has no post phase, so the revocation lives here instead. always(): the token must
+      # die even when the loop guard or the apply step failed, not only on success. Best-effort:
+      # a revocation hiccup must not turn a successful autofix commit into a failed job, and an
+      # unrevoked token still expires within the hour.
+      - if: ${{ always() && steps.app-token.outputs.token != '' }}
+        name: Revoke the installation token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api -X DELETE /installation/token || echo '::warning::Token revocation failed; the token expires on its own within an hour.'

--- a/.github/workflows/autofix-apply.yml
+++ b/.github/workflows/autofix-apply.yml
@@ -9,22 +9,26 @@ name: Apply autofix
 # workflow_run gives us exactly that separation: this job runs in the BASE repository's context,
 # from the DEFAULT branch's workflow definition, and executes no repository code — it only moves
 # a validated JSON patch into a commit.
+#
+# Credentials: the App's private key lives ONLY in the WillBooster token broker (a Cloudflare
+# Worker on a dedicated account) — never in GitHub Secrets. This job exchanges its OIDC ID token
+# for a short-lived installation token scoped to this one repository with contents:write; the
+# broker's policy pins the token's job_workflow_ref to this workflow's main-branch definition, so
+# no other workflow can obtain one. Callers configure nothing but `permissions: id-token: write`.
 on:
   workflow_call:
     inputs:
       target_organization:
         required: false
         type: string
-    secrets:
-      AUTOFIX_APP_PRIVATE_KEY:
-        description: Private key of that App. Never exposed to any step that runs repository code.
-        required: true
 
 permissions:
-  # Reading the triggering run's artifact. Note this is the workflow's OWN GITHUB_TOKEN; the
-  # commit itself uses the App token, because GITHUB_TOKEN pushes would not re-trigger checks.
+  # actions/contents: reading the triggering run's artifact with the workflow's OWN GITHUB_TOKEN;
+  # id-token: minting the OIDC ID token the broker exchange requires. The commit itself uses the
+  # broker-issued App token, because GITHUB_TOKEN pushes would not re-trigger checks.
   actions: read
   contents: read
+  id-token: write
 
 jobs:
   apply:
@@ -56,21 +60,16 @@ jobs:
             echo 'found=false' >> "$GITHUB_OUTPUT"
           fi
 
-      # Scoped deliberately narrower than the installation: one repository, and only the single
-      # permission the commit needs. An installation covering every repository in the organization
-      # therefore still yields a token that can write to exactly this one.
+      # The broker derives the token's target repository from the verified `repository` claim of
+      # the ID token and issues contents:write only, so an installation covering every repository
+      # in the organization still yields a token that can write to exactly this one. Same-repo
+      # `@main` reference, like apply-autofix-patch below: reusable-workflow jobs do not check out
+      # this repository, and the trust boundary stays within it.
       - if: ${{ steps.artifact.outputs.found == 'true' }}
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: WillBooster/reusable-workflows/.github/actions/broker-token@main
         with:
-          # Constant, not an input or a secret: one Autofixer App serves every organization, and
-          # an App ID is public anyway (an unauthenticated GET /apps/{slug} returns it) and useless
-          # without the private key. Keeping it out of the inputs leaves callers with nothing to
-          # configure but the key itself.
-          app-id: '4388928'
-          private-key: ${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
+          identity: autofix
 
       # A patch on top of a commit this App already made means the fixers did not converge: the
       # apply would push, re-trigger the tests, and produce another patch indefinitely. The old
@@ -78,13 +77,15 @@ jobs:
       # replaces a property we are deliberately giving up. Fail loudly rather than burn runners.
       # Matching the App's own bot login is exact: it identifies THIS App rather than any bot, and
       # it does not depend on `.author.type` (App bot authors do report `Bot` there — verified
-      # against renovate[bot] — but the login comparison needs no such assumption).
+      # against renovate[bot] — but the login comparison needs no such assumption). The slug is a
+      # hardcoded constant (public information) because the broker exchange, unlike the retired
+      # create-github-app-token step, has no app-slug output.
       - if: ${{ steps.artifact.outputs.found == 'true' }}
         name: Refuse to loop on non-convergent fixers
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_SLUG: willbooster-autofixer
         run: |
           AUTHOR="$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA" --jq '.author.login // ""')"
           if [[ "$AUTHOR" == "$APP_SLUG[bot]" ]]; then

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ on:
     types: [completed]
 jobs:
   apply:
-    # A called workflow can only REDUCE the caller's token, never elevate it, so the grant has to
-    # be here: without actions:read the job cannot list or download the triggering run's artifact.
+    # A called workflow can only REDUCE the caller's token, never elevate it, so the grants have
+    # to be here: without actions:read the job cannot list or download the triggering run's
+    # artifact, and without id-token:write it cannot mint the OIDC token the broker exchange needs.
     permissions:
       actions: read
       contents: read
+      id-token: write
     uses: WillBooster/reusable-workflows/.github/workflows/autofix-apply.yml@main
-    secrets:
-      AUTOFIX_APP_PRIVATE_KEY: ${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}
 ```
 
-- `AUTOFIX_APP_PRIVATE_KEY` is the only thing a caller configures. The App ID is a constant inside `autofix-apply.yml` — it is a public identifier, useless without the key, and one Autofixer App serves every organization, so there is no input to override. An organization wanting its own App needs a change to that workflow.
+- Callers configure no secret at all. The App's private key lives only in the [WillBooster token broker](https://github.com/WillBooster/github-token-broker) (a Cloudflare Worker on a dedicated account, never in GitHub Secrets); `autofix-apply.yml` exchanges its OIDC ID token for a one-hour installation token scoped to the calling repository with `contents: write` only. The broker's policy pins `job_workflow_ref` to this repository's main-branch `autofix-apply.yml`, so no other workflow can obtain a token. If the broker is down, the exchange fails and the patch is simply not committed (the test run already failed with the diff) — fail-closed.
 - An App push re-triggers `pull_request` **and** `pull_request_target`, so every required check — including `pull_request_target` ones such as `semantic-pr` — populates on the fixed commit. This is why the old `workflow_dispatch` workaround is gone.
 - Without this caller workflow the test job simply fails with the diff, which is the fail-closed fallback.
 - Fork pull requests are excluded: `workflow_run` carries the base repository's secrets, and the App cannot push to a fork's branch.


### PR DESCRIPTION
## Customer Summary

- Autofix commits on private-repository pull requests no longer require any GitHub secret: repositories calling `autofix-apply.yml` configure only a workflow permission (`id-token: write`).
- The GitHub App's private key now lives solely in the WillBooster token broker (a Cloudflare Worker on a dedicated account), so it can no longer be exfiltrated through GitHub Secrets.
- If the broker is unavailable, autofix commits simply do not happen (the test run still fails with the diff) — fail-closed, with no other impact.

## Technical Summary

- New `.github/actions/broker-token` composite action (shared by autofix now, wbfy later): mints an OIDC ID token with the dedicated audience `willbooster-token-broker` using bash + curl + jq only (no third-party action), POSTs it to `https://github-token-broker.willbooster-broker.workers.dev/token`, masks the returned installation token, and exposes it as the `token` output. Fails with an explicit message when the caller forgot `permissions: id-token: write`.
- `autofix-apply.yml`: replaces `actions/create-github-app-token` with the broker exchange (`identity: autofix`); deletes the `AUTOFIX_APP_PRIVATE_KEY` secret declaration outright (zero callers exist — verified via GitHub code search); adds `id-token: write`; the non-convergence guard compares against the hardcoded public slug `willbooster-autofixer` (verified to match App ID 4388928); and a new `always()` step revokes the installation token via `DELETE /installation/token` when the job ends (the retired action did this in its post step, which composite actions cannot have).
- README: the caller example passes no secret and grants `id-token: write`; documents the broker and the fail-closed behavior.

## Why

- A private key in GitHub Secrets is reachable by anyone (or any compromised account/CI dependency) with push access to a repository that can read it, and a leaked raw key grants indefinite, organization-wide `contents: write`. The broker returns only one-hour, single-repository tokens and pins its policy to this workflow's main-branch `job_workflow_ref`, so no other workflow can obtain one.
- Phase A′ of the migration plan: the reusable workflow must be secretless on main before the wbfy generator distributes secretless callers, or the callers would fail at startup passing an undeclared secret.

## Testing

- CI (test / semantic-pr) passes.
- Multi-agent review (`review-fix`: Codex, Claude Code, Antigravity) ran to convergence; the one valid finding (missing token revocation) is fixed. A round-2 reviewer verified the action's wire contract against the deployed broker end to end and exercised every broker-response failure mode of the action body under `bash -eo pipefail` against mock endpoints (all fail closed).
- The broker itself is deployed and live (its own unit tests cover the policy matrix).

## Notes

- Caller distribution (wbfy generator: `id-token: write`, secret pass-through removal, canonical-repository references) lands in WillBooster/shared#1109 after this merges.
- Known follow-up recorded in the plan: the loop guard's App slug is a constant duplicated from the broker's configuration; renaming the App would fail-open the guard until the broker exposes `app_slug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
