### PR TITLE
fix: drop the dead renovate/wbfy head_ref guards from the pre jobs

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   pre:
     # To avoid testing on synced (mirrored) repos.
-    if: ${{ !startsWith(github.head_ref, 'refs/heads/renovate/') && github.head_ref != 'refs/heads/wbfy' && (!inputs.target_organization || github.repository_owner == inputs.target_organization) }}
+    if: ${{ !inputs.target_organization || github.repository_owner == inputs.target_organization }}
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || fromJSON(format('["self-hosted", "{0}"]', inputs.ci_label)) }}
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   pre:
     # To avoid testing on synced (mirrored) repos.
-    if: ${{ !startsWith(github.head_ref, 'refs/heads/renovate/') && github.head_ref != 'refs/heads/wbfy' && (!inputs.target_organization || github.repository_owner == inputs.target_organization) }}
+    if: ${{ !inputs.target_organization || github.repository_owner == inputs.target_organization }}
     runs-on: ${{ (inputs.runs_on && fromJSON(inputs.runs_on)) || ((!github.event.repository.private || inputs.github_hosted_runner) && 'ubuntu-latest') || fromJSON('["self-hosted", "medium"]') }}
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}


### PR DESCRIPTION
## Customer Summary

- No behavior change: the removed conditions never matched, so test runs trigger exactly as before.
- The workflow guards are now easier to read and no longer reference the retired nightly wbfy flow.

## Technical Summary

- Removed `!startsWith(github.head_ref, 'refs/heads/renovate/') && github.head_ref != 'refs/heads/wbfy'` from the `pre` job `if:` of `test.yml` and `test-rust.yml`, keeping only the `target_organization` check that prevents runs on synced (mirrored) repositories.

## Why

- `github.head_ref` carries the bare branch name (e.g. `renovate/foo`, `wbfy`) without the `refs/heads/` prefix, so both comparisons were dead: the `startsWith` was always false and the inequality always true (including the empty `head_ref` on push events). Removing them preserves current behavior — renovate PRs must be tested — while dropping the reference to the `wbfy` branch pushed by the retired nightly self-applying wbfy flow (#485).

## Testing

- Multi-agent review (Claude / Codex / Antigravity) confirmed against GitHub's `github.head_ref` documentation and a grep of all other `head_ref` consumers that the removal is behavior-preserving; repository CI passed.
