### PR TITLE
feat(deploy): add deploy_max_attempts so fnox-based deploys can retry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@ on:
         default: .env
         required: false
         type: string
+      deploy_max_attempts:
+        # Attempts for the deploy step. By default only deploys that pass a platform secret
+        # (FLY_API_TOKEN / RAILWAY_API_TOKEN / GCP_SA_KEY_JSON) are retried; set this when the
+        # credentials come from elsewhere, such as fnox, so a flaky upload is still retried.
+        required: false
+        type: number
       environment:
         required: true
         type: string
@@ -554,7 +560,7 @@ jobs:
         uses: nick-fields/retry@dd56f1ca8ca991e2385c18ab6dd36ea7f9fdb55f
         with:
           timeout_minutes: 60
-          max_attempts: ${{ (env.HAS_FLY_API_TOKEN == 'true' || env.HAS_RAILWAY_API_TOKEN == 'true' || env.HAS_GCP_SA_KEY_JSON == 'true') && 20 || 1 }}
+          max_attempts: ${{ inputs.deploy_max_attempts || ((env.HAS_FLY_API_TOKEN == 'true' || env.HAS_RAILWAY_API_TOKEN == 'true' || env.HAS_GCP_SA_KEY_JSON == 'true') && 20 || 1) }}
           command: |
             : # The retry action runs this via `bash -c` without -e, so without this a failing
             : # deploy/ci-setup or cd would fall through and deploy anyway, reporting success.


### PR DESCRIPTION
## 問題

`deploy.yml` の Deploy ステップは、デプロイ先を示す secret(`FLY_API_TOKEN` / `RAILWAY_API_TOKEN` / `GCP_SA_KEY_JSON`)がワークフローに渡されたときだけ 20 回リトライし、それ以外は 1 回です。

認証情報を fnox へ移したリポジトリでは、これらの secret を渡さなくなるため、アップロードの一時的な失敗に対するリトライが失われます(WillBooster/coto-world#654 で発生)。デプロイの不安定さは認証情報の置き場所とは無関係なので、この判定は実態と合っていません。

## 変更

`deploy_max_attempts` 入力を追加し、呼び出し側が試行回数を明示できるようにしました。未指定時の挙動は従来どおりです(後方互換)。

## 備考

同じ secret に依存している箇所がもう一つあります: `check-gcloud` ステップは `HAS_GCP_SA_KEY_JSON == "true"` を前提としているため、fnox 移行後は gcloud のインストールと認証がスキップされます。coto-world は `mise.toml` で gcloud を pin し `deploy/ci-setup` で自前認証しているため実害はありませんが、fnox 移行するリポジトリが増えると問題になり得ます。本 PR のスコープ外とし、必要であれば別途対応します。
