### PR TITLE
feat: apply the release-age gate on GitHub-hosted runners and reject package managers too old to enforce it

### DIFF
--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -116,6 +116,13 @@ runs:
         $(printf "  - '%s'\n" "${EXCLUDES[@]}")
         $END_MARKER"
 
+        # bunx executes payloads cached under $TMPDIR/bunx-* without re-resolving, so on a
+        # persistent self-hosted runner a pre-gate cached payload would bypass the age gate.
+        # RUNNER_TEMP is emptied every job, which forces each job's first bunx resolution to
+        # happen under the gate (bun applies the global minimumReleaseAge to bunx resolution:
+        # bare/range specs fall back to the newest old-enough version, exact pins hard-fail).
+        echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+
         # Yarn 1 is exempt: the calling workflows still support Yarn 1 repositories even though it
         # cannot enforce any age gate (it ignores .yarnrc.yml, and npm's min-release-age does not
         # apply to its resolution) — a known policy gap, not an oversight.

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -68,8 +68,8 @@ runs:
             printf '    "%s",\n' "${EXCLUDES[@]}"
             printf ']\n'
           } > "$HOME/.bunfig.toml"
-          # min-release-age needs npm >= 11.10 and min-release-age-exclude needs npm >= 12; older
-          # npm only warns about the unknown keys, and yarn1 ignores them.
+          # min-release-age needs npm >= 11.10 and min-release-age-exclude needs npm >= 11.17;
+          # older npm only warns about the unknown keys, and yarn1 ignores them.
           {
             printf 'min-release-age=7\n'
             printf 'min-release-age-exclude[]=%s\n' "${EXCLUDES[@]}"

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -1,23 +1,23 @@
 name: Apply release-age gate
 description: >-
-  Force-overwrite the runner's GLOBAL package-manager configs (~/.bunfig.toml, ~/.yarnrc.yml,
-  ~/.npmrc) with the organization's 7-day minimum-release-age policy before any install.
-  Repository configs guard only wbfied repositories; consumers without a committed gate (and
-  freshly resolved versions in update/release runs) are otherwise unprotected on CI. Project-level
+  Write the organization's 7-day minimum-release-age policy into the GitHub-hosted runner's GLOBAL
+  package-manager configs (~/.bunfig.toml, ~/.yarnrc.yml, ~/.npmrc) before any install, and fail
+  the job when the selected package manager is too old to enforce the gate. Self-hosted runners
+  are provisioned by self-host-utils, whose scheduled wbfy runs write the same gate to their home
+  directories (ensureGlobalReleaseAgeGates in WillBooster/shared), so the config write is skipped
+  there; GitHub-hosted runners are ephemeral and can only be covered here. Project-level
   configuration takes precedence in all three managers, so wbfied repositories keep their own
-  (identical) gate and exclusion list. Hand-editing these global files on CI machines is not
-  permitted, so the whole file content is deliberately replaced on every run instead of merged —
-  any manual edit is discarded. Values and markers mirror wbfy's ensureGlobalReleaseAgeGates
-  (WillBooster/shared packages/wbfy/src/generators/globalReleaseAgeGate.ts) so a wbfy run on the
-  same machine recognizes and manages the same block instead of appending a duplicate.
+  (identical) gate and exclusion list.
 inputs:
   runner:
     description: >-
-      The install runner selected by the calling workflow's env-info step ('bun' or 'yarn'). When
-      'yarn', the action DELIBERATELY fails the job for Yarn Berry < 4.10: Yarn loads the home rc
-      in loose mode (yarnpkg/berry#2638), so older Berry silently ignores npmMinimalAgeGate and
-      would install ungated — which is not acceptable; the hard failure forces the repository to
-      upgrade to Yarn >= 4.10. Leave empty in jobs that never install with Yarn.
+      The package manager that resolves packages in this job ('bun' or 'yarn'; usually the calling
+      workflow's env-info runner output). Versions too old to enforce the gate silently ignore its
+      settings (Yarn loads the home rc in loose mode per yarnpkg/berry#2638, and Bun treats
+      minimumReleaseAge as an unknown bunfig key before 1.3.0) and would install ungated — which
+      is not acceptable, so the action DELIBERATELY fails the job for Yarn Berry < 4.10 and for
+      Bun < 1.3.0 to force an upgrade. Leave empty only in jobs that never install or resolve
+      packages with Yarn or Bun.
     default: ''
 runs:
   using: composite
@@ -27,12 +27,6 @@ runs:
       env:
         RUNNER: ${{ inputs.runner }}
       run: |
-        START_MARKER='# wbfy:start release-age-gate'
-        END_MARKER='# wbfy:end release-age-gate'
-        # 7 days, expressed in each manager's unit: seconds (Bun), minutes (Yarn), days (npm).
-        BUN_SECONDS=604800
-        YARN_MINUTES=10080
-        NPM_DAYS=7
         # Only the organization's own packages are exempt: we control who publishes them. Keep in
         # sync with bunMinimumReleaseAgeExcludes in WillBooster/shared
         # (packages/wbfy/src/generators/bunfig.ts) — that constant is the canonical vetted list.
@@ -63,65 +57,31 @@ runs:
           'vinext-progress'
         )
 
-        write_file() { # $1=path $2=content
-          local old_content=''
-          [[ -f "$1" ]] && old_content="$(cat "$1")"
-          [[ "$2" == "$old_content" ]] && return 0
-          # mktemp in the destination directory + mv: rename(2) replaces even a symlinked config
-          # itself (never writing through it), is atomic (no window where the file is missing or
-          # half-written for concurrent jobs on a persistent runner), and cannot degrade into a
-          # cross-filesystem copy.
-          local tmp
-          tmp="$(mktemp "$(dirname "$1")/.age-gate.XXXXXX")"
-          printf '%s\n' "$2" > "$tmp"
-          mv "$tmp" "$1"
-          echo "Applied the minimum-release-age policy to $1"
-        }
-
-        # ~/.bunfig.toml — Bun merges the global config under the project's per key, so wbfied
-        # repositories keep their committed (identical) gate. Bun ignores unknown bunfig keys, so
-        # versions predating minimumReleaseAge are unaffected. When XDG_CONFIG_HOME is set, Bun
-        # reads $XDG_CONFIG_HOME/.bunfig.toml INSTEAD of $HOME/.bunfig.toml, so that path must be
-        # managed (and created) whenever the variable is set; $HOME is still written for processes
-        # that run without the variable.
-        BUNFIG_CONTENT="$START_MARKER
-        [install]
-        minimumReleaseAge = $BUN_SECONDS # 7 days
-        minimumReleaseAgeExcludes = [
-        $(printf '    "%s",\n' "${EXCLUDES[@]}")
-        ]
-        $END_MARKER"
-        write_file "$HOME/.bunfig.toml" "$BUNFIG_CONTENT"
-        if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
-          mkdir -p "$XDG_CONFIG_HOME"
-          write_file "$XDG_CONFIG_HOME/.bunfig.toml" "$BUNFIG_CONTENT"
+        # Ephemeral GitHub-hosted runners start from a fresh $HOME with none of these files and do
+        # not set XDG_CONFIG_HOME, so plain overwrites of the $HOME paths suffice. The 7-day gate
+        # is expressed in each manager's unit: seconds (Bun), minutes (Yarn), days (npm).
+        if [[ "${RUNNER_ENVIRONMENT:-}" == 'github-hosted' ]]; then
+          # Bun ignores unknown bunfig keys, so versions predating minimumReleaseAge (< 1.3.0)
+          # are unaffected by this file; the version check below is what breaks them.
+          {
+            printf '[install]\nminimumReleaseAge = 604800 # 7 days\nminimumReleaseAgeExcludes = [\n'
+            printf '    "%s",\n' "${EXCLUDES[@]}"
+            printf ']\n'
+          } > "$HOME/.bunfig.toml"
+          # min-release-age needs npm >= 11.10 and min-release-age-exclude needs npm >= 12; older
+          # npm only warns about the unknown keys, and yarn1 ignores them.
+          {
+            printf 'min-release-age=7\n'
+            printf 'min-release-age-exclude[]=%s\n' "${EXCLUDES[@]}"
+          } > "$HOME/.npmrc"
+          # Minutes as a plain number: Yarn's duration parser silently ignores day suffixes
+          # (yarnpkg/berry#6991), which would disable the gate entirely.
+          {
+            printf 'npmMinimalAgeGate: 10080 # 7 days\nnpmPreapprovedPackages:\n'
+            printf "  - '%s'\n" "${EXCLUDES[@]}"
+          } > "$HOME/.yarnrc.yml"
+          echo 'Applied the minimum-release-age policy to ~/.bunfig.toml, ~/.npmrc, and ~/.yarnrc.yml'
         fi
-
-        # ~/.npmrc — no ${VAR} references, so unlike the credentialed project .npmrc it is safe to
-        # persist on self-hosted runners. min-release-age needs npm >= 11.10 and
-        # min-release-age-exclude needs npm >= 12; older npm only warns about the unknown keys,
-        # and yarn1 ignores them.
-        write_file "$HOME/.npmrc" "$START_MARKER
-        min-release-age=$NPM_DAYS
-        $(printf 'min-release-age-exclude[]=%s\n' "${EXCLUDES[@]}")
-        $END_MARKER"
-
-        # ~/.yarnrc.yml — npmMinimalAgeGate needs Yarn >= 4.10; the runner input check below is
-        # what breaks older Yarn (this file alone cannot, see the input description). Minutes as a
-        # plain number: Yarn's duration parser silently ignores day suffixes (yarnpkg/berry#6991),
-        # which would disable the gate entirely.
-        write_file "$HOME/.yarnrc.yml" "$START_MARKER
-        npmMinimalAgeGate: $YARN_MINUTES # 7 days
-        npmPreapprovedPackages:
-        $(printf "  - '%s'\n" "${EXCLUDES[@]}")
-        $END_MARKER"
-
-        # bunx executes payloads cached under $TMPDIR/bunx-* without re-resolving, so on a
-        # persistent self-hosted runner a pre-gate cached payload would bypass the age gate.
-        # RUNNER_TEMP is emptied every job, which forces each job's first bunx resolution to
-        # happen under the gate (bun applies the global minimumReleaseAge to bunx resolution:
-        # bare/range specs fall back to the newest old-enough version, exact pins hard-fail).
-        echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
 
         # Yarn 1 is exempt: the calling workflows still support Yarn 1 repositories even though it
         # cannot enforce any age gate (it ignores .yarnrc.yml, and npm's min-release-age does not

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -1,0 +1,146 @@
+name: Apply release-age gate
+description: >-
+  Apply the organization's 7-day minimum-release-age policy to the runner's GLOBAL package-manager
+  configs (~/.bunfig.toml, ~/.yarnrc.yml, ~/.npmrc) before any install. Repository configs guard
+  only wbfied repositories; consumers without a committed gate (and freshly resolved versions in
+  update/release runs) are otherwise unprotected on CI. Project-level configuration takes
+  precedence in all three managers, so wbfied repositories keep their own (identical) gate and
+  exclusion list. Values and markers mirror wbfy's ensureGlobalReleaseAgeGates
+  (WillBooster/shared packages/wbfy/src/generators/globalReleaseAgeGate.ts) so the two tools
+  manage the same block interchangeably on persistent self-hosted runners.
+runs:
+  using: composite
+  steps:
+    - name: Apply the minimum-release-age policy to global package-manager configs
+      shell: bash
+      run: |
+        START_MARKER='# wbfy:start release-age-gate'
+        END_MARKER='# wbfy:end release-age-gate'
+        # 7 days, expressed in each manager's unit: seconds (Bun), minutes (Yarn), days (npm).
+        BUN_SECONDS=604800
+        YARN_MINUTES=10080
+        NPM_DAYS=7
+        # Only the organization's own packages are exempt: we control who publishes them. Keep in
+        # sync with bunMinimumReleaseAgeExcludes in WillBooster/shared
+        # (packages/wbfy/src/generators/bunfig.ts) — that constant is the canonical vetted list.
+        EXCLUDES=(
+          '@exercode/problem-utils'
+          '@willbooster-private/agentic-workflows'
+          '@willbooster-private/ai-ocr'
+          '@willbooster-private/llm-proxy'
+          '@willbooster/agent-skills'
+          '@willbooster/babel-configs'
+          '@willbooster/monaco-loader'
+          '@willbooster/monaco-react'
+          '@willbooster/oxfmt-config'
+          '@willbooster/oxlint-config'
+          '@willbooster/prettier-config'
+          '@willbooster/react-frame-component'
+          '@willbooster/shared-lib'
+          '@willbooster/shared-lib-blitz-next'
+          '@willbooster/shared-lib-next'
+          '@willbooster/shared-lib-node'
+          '@willbooster/shared-lib-react'
+          '@willbooster/wb'
+          'agent-runtime-kit'
+          'at-decorators'
+          'build-ts'
+          'gen-i18n-ts'
+          'one-way-git-sync'
+          'vinext-progress'
+        )
+
+        strip_managed_block() {
+          [[ -f "$1" ]] || return 0
+          awk -v start="$START_MARKER" -v end="$END_MARKER" '
+            index($0, start) { skip = 1 }
+            !skip { print }
+            index($0, end) { skip = 0 }
+          ' "$1"
+        }
+        write_managed() { # $1=path $2=rest-without-block $3=managed block ('' = remove the block)
+          local new_content
+          if [[ -n "$2" && -n "$3" ]]; then
+            new_content="$2"$'\n\n'"$3"
+          else
+            new_content="$2$3"
+          fi
+          local old_content=''
+          [[ -f "$1" ]] && old_content="$(cat "$1")"
+          [[ "$new_content" == "$old_content" ]] && return 0
+          # mktemp + mv so a symlinked config cannot redirect the write into an unexpected target
+          # (the .npmrc generation pattern), and readers never observe a half-written file.
+          local tmp
+          tmp="$(mktemp "${RUNNER_TEMP:-/tmp}/age-gate.XXXXXX")"
+          printf '%s\n' "$new_content" > "$tmp"
+          rm -f "$1"
+          mv "$tmp" "$1"
+          echo "Applied the minimum-release-age policy to $1"
+        }
+
+        # ~/.bunfig.toml — Bun merges the global config under the project's per key, so wbfied
+        # repositories keep their committed (identical) gate. Bun ignores unknown bunfig keys, so
+        # versions predating minimumReleaseAge are unaffected. Bun also reads
+        # $XDG_CONFIG_HOME/.bunfig.toml with undocumented precedence when both exist; update it
+        # too so a stale copy there cannot win.
+        BUNFIG_BLOCK="$START_MARKER
+        [install]
+        minimumReleaseAge = $BUN_SECONDS # 7 days
+        minimumReleaseAgeExcludes = [
+        $(printf '    "%s",\n' "${EXCLUDES[@]}")
+        ]
+        $END_MARKER"
+        BUNFIG_PATHS=("$HOME/.bunfig.toml")
+        if [[ -n "${XDG_CONFIG_HOME:-}" && -f "$XDG_CONFIG_HOME/.bunfig.toml" ]]; then
+          BUNFIG_PATHS+=("$XDG_CONFIG_HOME/.bunfig.toml")
+        fi
+        for bunfig_path in "${BUNFIG_PATHS[@]}"; do
+          rest="$(strip_managed_block "$bunfig_path")"
+          # A hand-written [install] section (or gate key) outside the managed block would collide
+          # with the appended one — TOML forbids duplicate tables. Fail safe: warn and leave the
+          # file alone instead of corrupting it.
+          if grep -qE '^[ \t]*\[install]|minimumReleaseAge' <<< "$rest"; then
+            echo "::warning::Skipped updating $bunfig_path: it configures [install] or minimumReleaseAge outside the managed release-age-gate block."
+          else
+            write_managed "$bunfig_path" "$rest" "$BUNFIG_BLOCK"
+          fi
+        done
+
+        # ~/.npmrc — no ${VAR} references, so unlike the credentialed project .npmrc it is safe to
+        # persist on self-hosted runners; npm versions predating min-release-age (< 11.10) only
+        # warn about the unknown key, and yarn1 ignores it. npm has no exclusion setting yet.
+        NPMRC_PATH="$HOME/.npmrc"
+        rest="$(strip_managed_block "$NPMRC_PATH")"
+        if grep -qE '^[ \t]*min-release-age[ \t]*=' <<< "$rest"; then
+          echo "::warning::Skipped updating $NPMRC_PATH: it sets min-release-age outside the managed release-age-gate block."
+        else
+          write_managed "$NPMRC_PATH" "$rest" "$START_MARKER
+        min-release-age=$NPM_DAYS
+        $END_MARKER"
+        fi
+
+        # ~/.yarnrc.yml — npmMinimalAgeGate exists only in Yarn >= 4.10, and older Yarn Berry
+        # versions REJECT unknown settings, so the block is written only when the repository's own
+        # yarn is new enough — and actively removed otherwise, so on a persistent self-hosted
+        # runner a block written for one repository cannot break the next repository's older yarn.
+        # Minutes as a plain number: Yarn's duration parser silently ignores day suffixes
+        # (yarnpkg/berry#6899), which would disable the gate entirely.
+        YARNRC_PATH="$HOME/.yarnrc.yml"
+        YARN_VERSION=''
+        if command -v yarn > /dev/null; then
+          YARN_VERSION="$(yarn --version 2> /dev/null || true)"
+        fi
+        rest="$(strip_managed_block "$YARNRC_PATH")"
+        if grep -qE '^[ \t]*(npmMinimalAgeGate|npmPreapprovedPackages)[ \t]*:' <<< "$rest"; then
+          echo "::warning::Skipped updating $YARNRC_PATH: it sets npmMinimalAgeGate or npmPreapprovedPackages outside the managed release-age-gate block."
+        elif [[ -n "$YARN_VERSION" && "$YARN_VERSION" != 1.* ]] && \
+             [[ "$(printf '%s\n' 4.10.0 "$YARN_VERSION" | sort -V | head -n 1)" == '4.10.0' ]]; then
+          YARNRC_BLOCK="$START_MARKER
+        npmMinimalAgeGate: $YARN_MINUTES # 7 days
+        npmPreapprovedPackages:
+        $(printf "  - '%s'\n" "${EXCLUDES[@]}")
+        $END_MARKER"
+          write_managed "$YARNRC_PATH" "$rest" "$YARNRC_BLOCK"
+        elif [[ -f "$YARNRC_PATH" ]]; then
+          write_managed "$YARNRC_PATH" "$rest" ''
+        fi

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -120,27 +120,21 @@ runs:
         fi
 
         # ~/.yarnrc.yml — npmMinimalAgeGate exists only in Yarn >= 4.10, and older Yarn Berry
-        # versions REJECT unknown settings, so the block is written only when the repository's own
-        # yarn is new enough — and actively removed otherwise, so on a persistent self-hosted
-        # runner a block written for one repository cannot break the next repository's older yarn.
-        # Minutes as a plain number: Yarn's duration parser silently ignores day suffixes
-        # (yarnpkg/berry#6899), which would disable the gate entirely.
+        # versions REJECT unknown settings, so this block DELIBERATELY breaks their installs:
+        # running an old Yarn (without the age gate it cannot enforce) is not acceptable, and the
+        # hard failure forces the repository to upgrade to Yarn >= 4.10. Yarn 1 ignores
+        # .yarnrc.yml entirely and stays on the ~/.npmrc gate above. Minutes as a plain number:
+        # Yarn's duration parser silently ignores day suffixes (yarnpkg/berry#6899), which would
+        # disable the gate entirely.
         YARNRC_PATH="$HOME/.yarnrc.yml"
-        YARN_VERSION=''
-        if command -v yarn > /dev/null; then
-          YARN_VERSION="$(yarn --version 2> /dev/null || true)"
-        fi
         rest="$(strip_managed_block "$YARNRC_PATH")"
         if grep -qE '^[ \t]*(npmMinimalAgeGate|npmPreapprovedPackages)[ \t]*:' <<< "$rest"; then
           echo "::warning::Skipped updating $YARNRC_PATH: it sets npmMinimalAgeGate or npmPreapprovedPackages outside the managed release-age-gate block."
-        elif [[ -n "$YARN_VERSION" && "$YARN_VERSION" != 1.* ]] && \
-             [[ "$(printf '%s\n' 4.10.0 "$YARN_VERSION" | sort -V | head -n 1)" == '4.10.0' ]]; then
+        else
           YARNRC_BLOCK="$START_MARKER
         npmMinimalAgeGate: $YARN_MINUTES # 7 days
         npmPreapprovedPackages:
         $(printf "  - '%s'\n" "${EXCLUDES[@]}")
         $END_MARKER"
           write_managed "$YARNRC_PATH" "$rest" "$YARNRC_BLOCK"
-        elif [[ -f "$YARNRC_PATH" ]]; then
-          write_managed "$YARNRC_PATH" "$rest" ''
         fi

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -126,13 +126,21 @@ runs:
         # Yarn 1 is exempt: the calling workflows still support Yarn 1 repositories even though it
         # cannot enforce any age gate (it ignores .yarnrc.yml, and npm's min-release-age does not
         # apply to its resolution) — a known policy gap, not an oversight.
+        # No fallback in the probes below: when the workflow installs with the checked manager, a
+        # failed version probe must fail the job rather than silently skip the enforcement.
         if [[ "$RUNNER" == 'yarn' ]]; then
-          # No fallback: when the workflow installs with Yarn, a failed version probe must fail
-          # the job rather than silently skip the enforcement.
           YARN_VERSION="$(yarn --version)"
           if [[ "$YARN_VERSION" != 1.* ]] && \
              [[ "$(printf '%s\n' 4.10.0 "$YARN_VERSION" | sort -V | head -n 1)" != '4.10.0' ]]; then
             echo "::error::Yarn $YARN_VERSION cannot enforce npmMinimalAgeGate (requires Yarn >= 4.10), so installs would run without the organization's release-age gate; upgrade Yarn to >= 4.10."
+            exit 1
+          fi
+        elif [[ "$RUNNER" == 'bun' ]]; then
+          # Symmetric to the Yarn case: Bun < 1.3.0 (oven-sh/bun#22801) silently ignores
+          # minimumReleaseAge as an unknown bunfig key and would install ungated.
+          BUN_VERSION="$(bun --version)"
+          if [[ "$(printf '%s\n' 1.3.0 "$BUN_VERSION" | sort -V | head -n 1)" != '1.3.0' ]]; then
+            echo "::error::Bun $BUN_VERSION cannot enforce minimumReleaseAge (requires Bun >= 1.3.0), so installs would run without the organization's release-age gate; upgrade Bun to >= 1.3.0."
             exit 1
           fi
         fi

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -1,18 +1,31 @@
 name: Apply release-age gate
 description: >-
-  Apply the organization's 7-day minimum-release-age policy to the runner's GLOBAL package-manager
-  configs (~/.bunfig.toml, ~/.yarnrc.yml, ~/.npmrc) before any install. Repository configs guard
-  only wbfied repositories; consumers without a committed gate (and freshly resolved versions in
-  update/release runs) are otherwise unprotected on CI. Project-level configuration takes
-  precedence in all three managers, so wbfied repositories keep their own (identical) gate and
-  exclusion list. Values and markers mirror wbfy's ensureGlobalReleaseAgeGates
-  (WillBooster/shared packages/wbfy/src/generators/globalReleaseAgeGate.ts) so the two tools
-  manage the same block interchangeably on persistent self-hosted runners.
+  Force-overwrite the runner's GLOBAL package-manager configs (~/.bunfig.toml, ~/.yarnrc.yml,
+  ~/.npmrc) with the organization's 7-day minimum-release-age policy before any install.
+  Repository configs guard only wbfied repositories; consumers without a committed gate (and
+  freshly resolved versions in update/release runs) are otherwise unprotected on CI. Project-level
+  configuration takes precedence in all three managers, so wbfied repositories keep their own
+  (identical) gate and exclusion list. Hand-editing these global files on CI machines is not
+  permitted, so the whole file content is deliberately replaced on every run instead of merged —
+  any manual edit is discarded. Values and markers mirror wbfy's ensureGlobalReleaseAgeGates
+  (WillBooster/shared packages/wbfy/src/generators/globalReleaseAgeGate.ts) so a wbfy run on the
+  same machine recognizes and manages the same block instead of appending a duplicate.
+inputs:
+  runner:
+    description: >-
+      The install runner selected by the calling workflow's env-info step ('bun' or 'yarn'). When
+      'yarn', the action DELIBERATELY fails the job for Yarn Berry < 4.10: Yarn loads the home rc
+      in loose mode (yarnpkg/berry#2638), so older Berry silently ignores npmMinimalAgeGate and
+      would install ungated — which is not acceptable; the hard failure forces the repository to
+      upgrade to Yarn >= 4.10. Leave empty in jobs that never install with Yarn.
+    default: ''
 runs:
   using: composite
   steps:
     - name: Apply the minimum-release-age policy to global package-manager configs
       shell: bash
+      env:
+        RUNNER: ${{ inputs.runner }}
       run: |
         START_MARKER='# wbfy:start release-age-gate'
         END_MARKER='# wbfy:end release-age-gate'
@@ -50,33 +63,19 @@ runs:
           'vinext-progress'
         )
 
-        strip_managed_block() {
-          [[ -f "$1" ]] || return 0
-          awk -v start="$START_MARKER" -v end="$END_MARKER" '
-            index($0, start) { skip = 1 }
-            !skip { print }
-            index($0, end) { skip = 0 }
-          ' "$1"
-        }
-        write_file() { # $1=path $2=new content
+        write_file() { # $1=path $2=content
           local old_content=''
           [[ -f "$1" ]] && old_content="$(cat "$1")"
           [[ "$2" == "$old_content" ]] && return 0
-          # mktemp + mv so a symlinked config cannot redirect the write into an unexpected target
-          # (the .npmrc generation pattern), and readers never observe a half-written file.
+          # mktemp in the destination directory + mv: rename(2) replaces even a symlinked config
+          # itself (never writing through it), is atomic (no window where the file is missing or
+          # half-written for concurrent jobs on a persistent runner), and cannot degrade into a
+          # cross-filesystem copy.
           local tmp
-          tmp="$(mktemp "${RUNNER_TEMP:-/tmp}/age-gate.XXXXXX")"
+          tmp="$(mktemp "$(dirname "$1")/.age-gate.XXXXXX")"
           printf '%s\n' "$2" > "$tmp"
-          rm -f "$1"
           mv "$tmp" "$1"
           echo "Applied the minimum-release-age policy to $1"
-        }
-        join_block() { # $1=rest-without-block $2=block; prints the combined content
-          if [[ -n "$1" ]]; then
-            printf '%s\n\n%s' "$1" "$2"
-          else
-            printf '%s' "$2"
-          fi
         }
 
         # ~/.bunfig.toml — Bun merges the global config under the project's per key, so wbfied
@@ -85,95 +84,46 @@ runs:
         # reads $XDG_CONFIG_HOME/.bunfig.toml INSTEAD of $HOME/.bunfig.toml, so that path must be
         # managed (and created) whenever the variable is set; $HOME is still written for processes
         # that run without the variable.
-        BUNFIG_GATE_KEYS="$START_MARKER
+        BUNFIG_CONTENT="$START_MARKER
+        [install]
         minimumReleaseAge = $BUN_SECONDS # 7 days
         minimumReleaseAgeExcludes = [
         $(printf '    "%s",\n' "${EXCLUDES[@]}")
         ]
         $END_MARKER"
-        # The [install] header stays OUTSIDE the managed markers: TOML table scope continues after
-        # the end marker, so stripping a block that contained the header would silently move any
-        # keys a human appended below it to the top level on the next run.
-        INSTALL_HEADER_PATTERN='^ *\[[ "'\'']*install[ "'\'']*\] *(#.*)?$'
-        BUNFIG_PATHS=("$HOME/.bunfig.toml")
+        write_file "$HOME/.bunfig.toml" "$BUNFIG_CONTENT"
         if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
           mkdir -p "$XDG_CONFIG_HOME"
-          BUNFIG_PATHS+=("$XDG_CONFIG_HOME/.bunfig.toml")
+          write_file "$XDG_CONFIG_HOME/.bunfig.toml" "$BUNFIG_CONTENT"
         fi
-        for bunfig_path in "${BUNFIG_PATHS[@]}"; do
-          rest="$(strip_managed_block "$bunfig_path")"
-          # A hand-written gate key outside the managed block would collide with the managed one
-          # (TOML forbids duplicate keys). Fail safe: warn and leave the file alone instead of
-          # corrupting it. Assignments only — a comment merely mentioning the key is no conflict.
-          if grep -qE '^[ \t]*minimumReleaseAge(Excludes)?[ \t]*=' <<< "$rest"; then
-            echo "::warning::Skipped updating $bunfig_path: it sets minimumReleaseAge(Excludes) outside the managed release-age-gate block."
-          elif grep -qE "$INSTALL_HEADER_PATTERN" <<< "$rest"; then
-            # TOML forbids a second [install] header (quoted spellings like ["install"] are the
-            # same table), so insert the managed keys right after the existing header instead.
-            # Pure bash: BSD awk (macOS self-hosted runners) rejects -v values with newlines.
-            content=''
-            inserted=0
-            while IFS= read -r line; do
-              content+="$line"$'\n'
-              if [[ "$inserted" -eq 0 && "$line" =~ $INSTALL_HEADER_PATTERN ]]; then
-                content+="$BUNFIG_GATE_KEYS"$'\n'
-                inserted=1
-              fi
-            done <<< "$rest"
-            write_file "$bunfig_path" "${content%$'\n'}"
-          else
-            write_file "$bunfig_path" "$(join_block "$rest" "[install]
-        $BUNFIG_GATE_KEYS")"
-          fi
-        done
 
         # ~/.npmrc — no ${VAR} references, so unlike the credentialed project .npmrc it is safe to
         # persist on self-hosted runners. min-release-age needs npm >= 11.10 and
         # min-release-age-exclude needs npm >= 12; older npm only warns about the unknown keys,
         # and yarn1 ignores them.
-        NPMRC_PATH="$HOME/.npmrc"
-        rest="$(strip_managed_block "$NPMRC_PATH")"
-        if grep -qE '^[ \t]*min-release-age(-exclude(\[])?)?[ \t]*=' <<< "$rest"; then
-          echo "::warning::Skipped updating $NPMRC_PATH: it sets min-release-age or min-release-age-exclude outside the managed release-age-gate block."
-        else
-          write_file "$NPMRC_PATH" "$(join_block "$rest" "$START_MARKER
+        write_file "$HOME/.npmrc" "$START_MARKER
         min-release-age=$NPM_DAYS
         $(printf 'min-release-age-exclude[]=%s\n' "${EXCLUDES[@]}")
-        $END_MARKER")"
-        fi
+        $END_MARKER"
 
-        # ~/.yarnrc.yml — npmMinimalAgeGate exists only in Yarn >= 4.10. Yarn Berry loads the HOME
-        # rc in loose mode (yarnpkg/berry#2638), so older Berry versions silently IGNORE these
-        # keys instead of erroring — writing the block alone cannot break them; the explicit
-        # version check below does. Minutes as a plain number: Yarn's duration parser silently
-        # ignores day suffixes (yarnpkg/berry#6899), which would disable the gate entirely.
-        YARNRC_PATH="$HOME/.yarnrc.yml"
-        rest="$(strip_managed_block "$YARNRC_PATH")"
-        if grep -qE '^[ \t]*(npmMinimalAgeGate|npmPreapprovedPackages)[ \t]*:' <<< "$rest"; then
-          echo "::warning::Skipped updating $YARNRC_PATH: it sets npmMinimalAgeGate or npmPreapprovedPackages outside the managed release-age-gate block."
-        elif grep -qE '^\.\.\.[ \t]*$' <<< "$rest"; then
-          # Content appended after a YAML document-end marker makes the file unparsable for every
-          # yarn command; leave such a file alone instead of breaking it.
-          echo "::warning::Skipped updating $YARNRC_PATH: it contains a YAML document-end marker (...), so the managed block cannot be appended safely."
-        else
-          write_file "$YARNRC_PATH" "$(join_block "$rest" "$START_MARKER
+        # ~/.yarnrc.yml — npmMinimalAgeGate needs Yarn >= 4.10; the runner input check below is
+        # what breaks older Yarn (this file alone cannot, see the input description). Minutes as a
+        # plain number: Yarn's duration parser silently ignores day suffixes (yarnpkg/berry#6991),
+        # which would disable the gate entirely.
+        write_file "$HOME/.yarnrc.yml" "$START_MARKER
         npmMinimalAgeGate: $YARN_MINUTES # 7 days
         npmPreapprovedPackages:
         $(printf "  - '%s'\n" "${EXCLUDES[@]}")
-        $END_MARKER")"
-        fi
+        $END_MARKER"
 
-        # Running an old Yarn without an enforceable age gate is NOT acceptable, and the block
-        # above cannot break it by itself (loose mode, see above) — so DELIBERATELY fail the job
-        # to force the repository to upgrade to Yarn >= 4.10. yarn.lock limits the check to
-        # repositories that actually install with Yarn: a preinstalled or mise-provided global
-        # yarn must not fail bun repositories. Yarn 1 is exempt for now because the calling
-        # workflows still support Yarn 1 repositories — note that it cannot enforce any age gate
-        # (it ignores .yarnrc.yml, and npm's min-release-age does not apply to its resolution),
-        # which is a known policy gap, not an oversight.
-        if [[ -f yarn.lock ]] && command -v yarn > /dev/null; then
-          YARN_VERSION="$(yarn --version 2> /dev/null || true)"
-          if [[ -n "$YARN_VERSION" && "$YARN_VERSION" != 1.* ]] && \
+        # Yarn 1 is exempt: the calling workflows still support Yarn 1 repositories even though it
+        # cannot enforce any age gate (it ignores .yarnrc.yml, and npm's min-release-age does not
+        # apply to its resolution) — a known policy gap, not an oversight.
+        if [[ "$RUNNER" == 'yarn' ]]; then
+          # No fallback: when the workflow installs with Yarn, a failed version probe must fail
+          # the job rather than silently skip the enforcement.
+          YARN_VERSION="$(yarn --version)"
+          if [[ "$YARN_VERSION" != 1.* ]] && \
              [[ "$(printf '%s\n' 4.10.0 "$YARN_VERSION" | sort -V | head -n 1)" != '4.10.0' ]]; then
             echo "::error::Yarn $YARN_VERSION cannot enforce npmMinimalAgeGate (requires Yarn >= 4.10), so installs would run without the organization's release-age gate; upgrade Yarn to >= 4.10."
             exit 1

--- a/.github/actions/apply-release-age-gate/action.yml
+++ b/.github/actions/apply-release-age-gate/action.yml
@@ -58,83 +58,124 @@ runs:
             index($0, end) { skip = 0 }
           ' "$1"
         }
-        write_managed() { # $1=path $2=rest-without-block $3=managed block ('' = remove the block)
-          local new_content
-          if [[ -n "$2" && -n "$3" ]]; then
-            new_content="$2"$'\n\n'"$3"
-          else
-            new_content="$2$3"
-          fi
+        write_file() { # $1=path $2=new content
           local old_content=''
           [[ -f "$1" ]] && old_content="$(cat "$1")"
-          [[ "$new_content" == "$old_content" ]] && return 0
+          [[ "$2" == "$old_content" ]] && return 0
           # mktemp + mv so a symlinked config cannot redirect the write into an unexpected target
           # (the .npmrc generation pattern), and readers never observe a half-written file.
           local tmp
           tmp="$(mktemp "${RUNNER_TEMP:-/tmp}/age-gate.XXXXXX")"
-          printf '%s\n' "$new_content" > "$tmp"
+          printf '%s\n' "$2" > "$tmp"
           rm -f "$1"
           mv "$tmp" "$1"
           echo "Applied the minimum-release-age policy to $1"
         }
+        join_block() { # $1=rest-without-block $2=block; prints the combined content
+          if [[ -n "$1" ]]; then
+            printf '%s\n\n%s' "$1" "$2"
+          else
+            printf '%s' "$2"
+          fi
+        }
 
         # ~/.bunfig.toml — Bun merges the global config under the project's per key, so wbfied
         # repositories keep their committed (identical) gate. Bun ignores unknown bunfig keys, so
-        # versions predating minimumReleaseAge are unaffected. Bun also reads
-        # $XDG_CONFIG_HOME/.bunfig.toml with undocumented precedence when both exist; update it
-        # too so a stale copy there cannot win.
-        BUNFIG_BLOCK="$START_MARKER
-        [install]
+        # versions predating minimumReleaseAge are unaffected. When XDG_CONFIG_HOME is set, Bun
+        # reads $XDG_CONFIG_HOME/.bunfig.toml INSTEAD of $HOME/.bunfig.toml, so that path must be
+        # managed (and created) whenever the variable is set; $HOME is still written for processes
+        # that run without the variable.
+        BUNFIG_GATE_KEYS="$START_MARKER
         minimumReleaseAge = $BUN_SECONDS # 7 days
         minimumReleaseAgeExcludes = [
         $(printf '    "%s",\n' "${EXCLUDES[@]}")
         ]
         $END_MARKER"
+        # The [install] header stays OUTSIDE the managed markers: TOML table scope continues after
+        # the end marker, so stripping a block that contained the header would silently move any
+        # keys a human appended below it to the top level on the next run.
+        INSTALL_HEADER_PATTERN='^ *\[[ "'\'']*install[ "'\'']*\] *(#.*)?$'
         BUNFIG_PATHS=("$HOME/.bunfig.toml")
-        if [[ -n "${XDG_CONFIG_HOME:-}" && -f "$XDG_CONFIG_HOME/.bunfig.toml" ]]; then
+        if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+          mkdir -p "$XDG_CONFIG_HOME"
           BUNFIG_PATHS+=("$XDG_CONFIG_HOME/.bunfig.toml")
         fi
         for bunfig_path in "${BUNFIG_PATHS[@]}"; do
           rest="$(strip_managed_block "$bunfig_path")"
-          # A hand-written [install] section (or gate key) outside the managed block would collide
-          # with the appended one — TOML forbids duplicate tables. Fail safe: warn and leave the
-          # file alone instead of corrupting it.
-          if grep -qE '^[ \t]*\[install]|minimumReleaseAge' <<< "$rest"; then
-            echo "::warning::Skipped updating $bunfig_path: it configures [install] or minimumReleaseAge outside the managed release-age-gate block."
+          # A hand-written gate key outside the managed block would collide with the managed one
+          # (TOML forbids duplicate keys). Fail safe: warn and leave the file alone instead of
+          # corrupting it. Assignments only — a comment merely mentioning the key is no conflict.
+          if grep -qE '^[ \t]*minimumReleaseAge(Excludes)?[ \t]*=' <<< "$rest"; then
+            echo "::warning::Skipped updating $bunfig_path: it sets minimumReleaseAge(Excludes) outside the managed release-age-gate block."
+          elif grep -qE "$INSTALL_HEADER_PATTERN" <<< "$rest"; then
+            # TOML forbids a second [install] header (quoted spellings like ["install"] are the
+            # same table), so insert the managed keys right after the existing header instead.
+            # Pure bash: BSD awk (macOS self-hosted runners) rejects -v values with newlines.
+            content=''
+            inserted=0
+            while IFS= read -r line; do
+              content+="$line"$'\n'
+              if [[ "$inserted" -eq 0 && "$line" =~ $INSTALL_HEADER_PATTERN ]]; then
+                content+="$BUNFIG_GATE_KEYS"$'\n'
+                inserted=1
+              fi
+            done <<< "$rest"
+            write_file "$bunfig_path" "${content%$'\n'}"
           else
-            write_managed "$bunfig_path" "$rest" "$BUNFIG_BLOCK"
+            write_file "$bunfig_path" "$(join_block "$rest" "[install]
+        $BUNFIG_GATE_KEYS")"
           fi
         done
 
         # ~/.npmrc — no ${VAR} references, so unlike the credentialed project .npmrc it is safe to
-        # persist on self-hosted runners; npm versions predating min-release-age (< 11.10) only
-        # warn about the unknown key, and yarn1 ignores it. npm has no exclusion setting yet.
+        # persist on self-hosted runners. min-release-age needs npm >= 11.10 and
+        # min-release-age-exclude needs npm >= 12; older npm only warns about the unknown keys,
+        # and yarn1 ignores them.
         NPMRC_PATH="$HOME/.npmrc"
         rest="$(strip_managed_block "$NPMRC_PATH")"
-        if grep -qE '^[ \t]*min-release-age[ \t]*=' <<< "$rest"; then
-          echo "::warning::Skipped updating $NPMRC_PATH: it sets min-release-age outside the managed release-age-gate block."
+        if grep -qE '^[ \t]*min-release-age(-exclude(\[])?)?[ \t]*=' <<< "$rest"; then
+          echo "::warning::Skipped updating $NPMRC_PATH: it sets min-release-age or min-release-age-exclude outside the managed release-age-gate block."
         else
-          write_managed "$NPMRC_PATH" "$rest" "$START_MARKER
+          write_file "$NPMRC_PATH" "$(join_block "$rest" "$START_MARKER
         min-release-age=$NPM_DAYS
-        $END_MARKER"
+        $(printf 'min-release-age-exclude[]=%s\n' "${EXCLUDES[@]}")
+        $END_MARKER")"
         fi
 
-        # ~/.yarnrc.yml — npmMinimalAgeGate exists only in Yarn >= 4.10, and older Yarn Berry
-        # versions REJECT unknown settings, so this block DELIBERATELY breaks their installs:
-        # running an old Yarn (without the age gate it cannot enforce) is not acceptable, and the
-        # hard failure forces the repository to upgrade to Yarn >= 4.10. Yarn 1 ignores
-        # .yarnrc.yml entirely and stays on the ~/.npmrc gate above. Minutes as a plain number:
-        # Yarn's duration parser silently ignores day suffixes (yarnpkg/berry#6899), which would
-        # disable the gate entirely.
+        # ~/.yarnrc.yml — npmMinimalAgeGate exists only in Yarn >= 4.10. Yarn Berry loads the HOME
+        # rc in loose mode (yarnpkg/berry#2638), so older Berry versions silently IGNORE these
+        # keys instead of erroring — writing the block alone cannot break them; the explicit
+        # version check below does. Minutes as a plain number: Yarn's duration parser silently
+        # ignores day suffixes (yarnpkg/berry#6899), which would disable the gate entirely.
         YARNRC_PATH="$HOME/.yarnrc.yml"
         rest="$(strip_managed_block "$YARNRC_PATH")"
         if grep -qE '^[ \t]*(npmMinimalAgeGate|npmPreapprovedPackages)[ \t]*:' <<< "$rest"; then
           echo "::warning::Skipped updating $YARNRC_PATH: it sets npmMinimalAgeGate or npmPreapprovedPackages outside the managed release-age-gate block."
+        elif grep -qE '^\.\.\.[ \t]*$' <<< "$rest"; then
+          # Content appended after a YAML document-end marker makes the file unparsable for every
+          # yarn command; leave such a file alone instead of breaking it.
+          echo "::warning::Skipped updating $YARNRC_PATH: it contains a YAML document-end marker (...), so the managed block cannot be appended safely."
         else
-          YARNRC_BLOCK="$START_MARKER
+          write_file "$YARNRC_PATH" "$(join_block "$rest" "$START_MARKER
         npmMinimalAgeGate: $YARN_MINUTES # 7 days
         npmPreapprovedPackages:
         $(printf "  - '%s'\n" "${EXCLUDES[@]}")
-        $END_MARKER"
-          write_managed "$YARNRC_PATH" "$rest" "$YARNRC_BLOCK"
+        $END_MARKER")"
+        fi
+
+        # Running an old Yarn without an enforceable age gate is NOT acceptable, and the block
+        # above cannot break it by itself (loose mode, see above) — so DELIBERATELY fail the job
+        # to force the repository to upgrade to Yarn >= 4.10. yarn.lock limits the check to
+        # repositories that actually install with Yarn: a preinstalled or mise-provided global
+        # yarn must not fail bun repositories. Yarn 1 is exempt for now because the calling
+        # workflows still support Yarn 1 repositories — note that it cannot enforce any age gate
+        # (it ignores .yarnrc.yml, and npm's min-release-age does not apply to its resolution),
+        # which is a known policy gap, not an oversight.
+        if [[ -f yarn.lock ]] && command -v yarn > /dev/null; then
+          YARN_VERSION="$(yarn --version 2> /dev/null || true)"
+          if [[ -n "$YARN_VERSION" && "$YARN_VERSION" != 1.* ]] && \
+             [[ "$(printf '%s\n' 4.10.0 "$YARN_VERSION" | sort -V | head -n 1)" != '4.10.0' ]]; then
+            echo "::error::Yarn $YARN_VERSION cannot enforce npmMinimalAgeGate (requires Yarn >= 4.10), so installs would run without the organization's release-age gate; upgrade Yarn to >= 4.10."
+            exit 1
+          fi
         fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,6 +285,8 @@ jobs:
       # must be age-gated even for repositories without a committed gate in their own configs.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
+        with:
+          runner: ${{ steps.env-info.outputs.runner }}
       - name: Set environment variables
         run: |
           echo "PATH=$HOME/.fly/bin:$PATH" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,8 +281,9 @@ jobs:
 
           if gcloud -v &> /dev/null; then echo "gcloud: $(gcloud -v 2>&1 | head -n 1)"; fi
 
-      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
-      # must be age-gated even for repositories without a committed gate in their own configs.
+      # Before every install: on ephemeral GitHub-hosted runners this writes the global release-age
+      # gate (self-hosted runners get it from self-host-utils via wbfy), and in both environments
+      # it fails the job when the selected package manager is too old to enforce the gate.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,6 +281,10 @@ jobs:
 
           if gcloud -v &> /dev/null; then echo "gcloud: $(gcloud -v 2>&1 | head -n 1)"; fi
 
+      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
+      # must be age-gated even for repositories without a committed gate in their own configs.
+      - name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - name: Set environment variables
         run: |
           echo "PATH=$HOME/.fly/bin:$PATH" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,10 @@ jobs:
             echo "hardened-install=true" >> $GITHUB_OUTPUT
           fi
 
+      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
+      # must be age-gated even for repositories without a committed gate in their own configs.
+      - name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - if: ${{ steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,8 @@ jobs:
       # must be age-gated even for repositories without a committed gate in their own configs.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
+        with:
+          runner: ${{ steps.env-info.outputs.runner }}
       - if: ${{ steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,9 @@ jobs:
             echo "hardened-install=true" >> $GITHUB_OUTPUT
           fi
 
-      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
-      # must be age-gated even for repositories without a committed gate in their own configs.
+      # Before every install: on ephemeral GitHub-hosted runners this writes the global release-age
+      # gate (self-hosted runners get it from self-host-utils via wbfy), and in both environments
+      # it fails the job when the selected package manager is too old to enforce the gate.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
         with:

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -207,6 +207,10 @@ jobs:
           if [[ "$HAS_VERDACCIO_TOKEN" == "true" || ("$HAS_TAKUMI_GUARD_TOKEN" == "true" && -n "${NPMRC_AWARE:-}") ]]; then
             echo "hardened-install=true" >> $GITHUB_OUTPUT
           fi
+      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
+      # must be age-gated even for repositories without a committed gate in their own configs.
+      - name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - if: ${{ steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -211,6 +211,8 @@ jobs:
       # must be age-gated even for repositories without a committed gate in their own configs.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
+        with:
+          runner: ${{ steps.env-info.outputs.runner }}
       - if: ${{ steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -207,8 +207,9 @@ jobs:
           if [[ "$HAS_VERDACCIO_TOKEN" == "true" || ("$HAS_TAKUMI_GUARD_TOKEN" == "true" && -n "${NPMRC_AWARE:-}") ]]; then
             echo "hardened-install=true" >> $GITHUB_OUTPUT
           fi
-      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
-      # must be age-gated even for repositories without a committed gate in their own configs.
+      # Before every install: on ephemeral GitHub-hosted runners this writes the global release-age
+      # gate (self-hosted runners get it from self-host-utils via wbfy), and in both environments
+      # it fails the job when the selected package manager is too old to enforce the gate.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
         with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -40,13 +40,10 @@ jobs:
           bun-version: latest
       # The global gate age-gates the one-way-git-sync dependency tree resolved by bunx below
       # (one-way-git-sync itself is an organization package on the exclusion list, so only its
-      # transitive dependencies are gated).
+      # transitive dependencies are gated). The action also isolates TMPDIR so a pre-gate bunx
+      # payload cache cannot bypass the gate.
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
-      # bunx reuses payloads cached under $TMPDIR/bunx-*, so on the persistent self-hosted runner
-      # a pre-gate cached one-way-git-sync would bypass the age gate; RUNNER_TEMP is emptied every
-      # job, which forces the first bunx resolution of each run to happen under the gate.
-      - run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Show environment information
         run: |
           echo "bun: $(bun -v)"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -38,12 +38,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
-      # The global gate age-gates the one-way-git-sync dependency tree resolved by bunx below
-      # (one-way-git-sync itself is an organization package on the exclusion list, so only its
-      # transitive dependencies are gated). The action also isolates TMPDIR so a pre-gate bunx
-      # payload cache cannot bypass the gate.
-      - name: Apply the minimum-release-age policy to global package-manager configs
-        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - name: Show environment information
         run: |
           echo "bun: $(bun -v)"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -38,11 +38,15 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
-      # bunx resolves one-way-git-sync and its dependencies fresh on every run; the global gate
-      # age-gates the dependency tree (one-way-git-sync itself is an organization package on the
-      # exclusion list, so only its transitive dependencies are gated).
+      # The global gate age-gates the one-way-git-sync dependency tree resolved by bunx below
+      # (one-way-git-sync itself is an organization package on the exclusion list, so only its
+      # transitive dependencies are gated).
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
+      # bunx reuses payloads cached under $TMPDIR/bunx-*, so on the persistent self-hosted runner
+      # a pre-gate cached one-way-git-sync would bypass the age gate; RUNNER_TEMP is emptied every
+      # job, which forces the first bunx resolution of each run to happen under the gate.
+      - run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Show environment information
         run: |
           echo "bun: $(bun -v)"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
-      # bunx resolves one-way-git-sync (and its dependencies) fresh on every run; the global gate
-      # keeps those resolutions age-gated.
+      # bunx resolves one-way-git-sync and its dependencies fresh on every run; the global gate
+      # age-gates the dependency tree (one-way-git-sync itself is an organization package on the
+      # exclusion list, so only its transitive dependencies are gated).
       - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - name: Show environment information

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -38,6 +38,10 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
+      # bunx resolves one-way-git-sync (and its dependencies) fresh on every run; the global gate
+      # keeps those resolutions age-gated.
+      - name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - name: Show environment information
         run: |
           echo "bun: $(bun -v)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,10 @@ jobs:
         with:
           check-latest: true
           node-version: lts/*
+      # The npx -y semver fallback below resolves a fresh version from the registry.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' }}
+        name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         id: detect-node-version-matrix
         # We must use actions/setup-node if no Node.js description exists in mise-managed files and no .node-version exists.
@@ -279,8 +283,9 @@ jobs:
 
       # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
       # must be age-gated even for repositories without a committed gate in their own configs.
-      - if: ${{ needs.pre.outputs.should_skip != 'true' }}
-        name: Apply the minimum-release-age policy to global package-manager configs
+      # Unconditional (no should_skip guard): the always() cleanup step resolves
+      # `npx --yes kill-port@latest` even on skipped runs, and that resolution must be gated too.
+      - name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,10 @@ jobs:
              ! ([[ -f .tool-versions ]] && grep -qE '^(node|nodejs)[[:space:]]' .tool-versions) && \
              ! ([[ -f mise.toml ]] && grep -qE '^[[:space:]]*(node|nodejs)[[:space:]]*=' mise.toml); then
             CONSTRAINT=$(node -e "console.log(((require('./package.json') || {}).engines || {}).node)")
-            NODE_VERSIONS=$(npx -y semver -r "$CONSTRAINT" 14.999.999 16.999.999 18.999.999 20.999.999 22.999.999 24.999.999 | xargs | sed 's/ /","/g' | sed 's/\.999\.999//g')
+            : # Pinned: this job may run with a preinstalled npm < 11.10 that ignores the
+            : # min-release-age gate, and published npm versions are immutable, so a pin removes
+            : # the freshly-resolved-latest exposure the gate cannot cover here.
+            NODE_VERSIONS=$(npx -y semver@7.8.5 -r "$CONSTRAINT" 14.999.999 16.999.999 18.999.999 20.999.999 22.999.999 24.999.999 | xargs | sed 's/ /","/g' | sed 's/\.999\.999//g')
           fi
           echo "json=[\"$NODE_VERSIONS\"]" >> $GITHUB_OUTPUT
   test:
@@ -694,4 +697,6 @@ jobs:
           : # port — lsof instead of `npx kill-port`: this always() step must not resolve a fresh
           : # package from the registry (it can run before/without the release-age gate, and the
           : # legacy-Node matrix legs have npm versions that ignore min-release-age anyway).
-          (lsof -t -i :3000 | xargs kill -9) 2> /dev/null &
+          : # LISTEN only: a bare `-i :3000` also matches processes merely CONNECTED to port 3000
+          : # (e.g. another job's test client on this shared runner), which must not be killed.
+          (lsof -t -i TCP:3000 -sTCP:LISTEN | xargs -r kill -9) 2> /dev/null &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,10 +283,11 @@ jobs:
 
       # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
       # must be age-gated even for repositories without a committed gate in their own configs.
-      # Unconditional (no should_skip guard): the always() cleanup step resolves
-      # `npx --yes kill-port@latest` even on skipped runs, and that resolution must be gated too.
-      - name: Apply the minimum-release-age policy to global package-manager configs
+      - if: ${{ needs.pre.outputs.should_skip != 'true' }}
+        name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
+        with:
+          runner: ${{ steps.env-info.outputs.runner }}
       - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:
@@ -690,5 +691,7 @@ jobs:
           if [[ ! $(docker ps) ]]; then
             (which docker && sleep 5 && sudo reboot) &
           fi
-          : # port
-          npx --yes kill-port@latest 3000 > /dev/null &
+          : # port — lsof instead of `npx kill-port`: this always() step must not resolve a fresh
+          : # package from the registry (it can run before/without the release-age gate, and the
+          : # legacy-Node matrix legs have npm versions that ignore min-release-age anyway).
+          (lsof -t -i :3000 | xargs kill -9) 2> /dev/null &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,6 +277,11 @@ jobs:
             poetry config virtualenvs.in-project true
           fi
 
+      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
+      # must be age-gated even for repositories without a committed gate in their own configs.
+      - if: ${{ needs.pre.outputs.should_skip != 'true' }}
+        name: Apply the minimum-release-age policy to global package-manager configs
+        uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main
       - if: ${{ needs.pre.outputs.should_skip != 'true' && steps.env-info.outputs.yarn-dir }}
         uses: actions/cache@v6.1.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,8 @@ jobs:
         with:
           check-latest: true
           node-version: lts/*
-      # The npx -y semver fallback below resolves a fresh version from the registry.
+      # The npx call below is pinned (see its comment), so the gate protects only any other or
+      # future registry resolution in this job, on runners whose npm honours min-release-age.
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,8 +285,9 @@ jobs:
             poetry config virtualenvs.in-project true
           fi
 
-      # Before every install: freshly RESOLVED versions (update/release runs, non-frozen installs)
-      # must be age-gated even for repositories without a committed gate in their own configs.
+      # Before every install: on ephemeral GitHub-hosted runners this writes the global release-age
+      # gate (self-hosted runners get it from self-host-utils via wbfy), and in both environments
+      # it fails the job when the selected package manager is too old to enforce the gate.
       - if: ${{ needs.pre.outputs.should_skip != 'true' }}
         name: Apply the minimum-release-age policy to global package-manager configs
         uses: WillBooster/reusable-workflows/.github/actions/apply-release-age-gate@main


### PR DESCRIPTION
## Customer Summary

- 組織の 7 日間 minimum-release-age ポリシー(公開直後のパッケージバージョンを使わない)が、GitHub-hosted ランナー上の CI(public リポジトリ等)でも自動的に適用されるようになります。
- gate を強制できない古いパッケージマネージャー(Yarn Berry < 4.10、Bun < 1.3.0)で install するジョブは、意図的に CI が失敗し、アップグレードを促します。
- self-hosted ランナーは従来どおり self-host-utils(wbfy の定期実行)がマシン側でカバーするため、挙動は変わりません。

## Technical Summary

- 新 composite action `apply-release-age-gate` を追加し、test / run-script / release / deploy の各 reusable workflow の install 前(env-info 直後)に組み込み。
  - `RUNNER_ENVIRONMENT == github-hosted` のときだけ、`~/.bunfig.toml`(`minimumReleaseAge = 604800` 秒 + 除外リスト)、`~/.npmrc`(`min-release-age=7` 日 + `min-release-age-exclude[]`、npm >= 11.10 / 11.17)、`~/.yarnrc.yml`(`npmMinimalAgeGate: 10080` 分 + `npmPreapprovedPackages`)を固定内容で上書き生成。エフェメラルな fresh $HOME 前提なので、マージ処理・managed マーカー・XDG 対応・アトミック書き込みは持たない最小実装。
  - `runner` 入力(env-info の runner 出力)が `yarn` / `bun` のとき、gate を黙って無視するバージョン(Yarn Berry < 4.10 は home rc を loose mode で読む yarnpkg/berry#2638、Bun < 1.3.0 は unknown key 扱い oven-sh/bun#22801)を両環境で hard-fail。Yarn 1 は既知のポリシーギャップとして免除(コメントに明記)。
- 除外リストは wbfy の `bunMinimumReleaseAgeExcludes`(WillBooster/shared#1176)と同一の組織パッケージ 24 件。3 マネージャーともプロジェクト設定がグローバルより優先されるため、wbfy 済みリポジトリの挙動は不変。lockfile 済みバージョンは再検証されないため、既存の frozen/immutable install も不変(bun/yarn/npm で検証済み)。
- 付随する hardening: test.yml の `detect-node-version-matrix` の `npx -y semver` を `semver@7.8.5` に pin(古い npm は gate を無視するため)、always() cleanup の `npx kill-port@latest` を `lsof -t -i TCP:3000 -sTCP:LISTEN | xargs -r kill -9` に置換(cleanup からレジストリ解決を排除、LISTEN 限定で共有ランナーの他ジョブのクライアントを殺さない)。

## Why

- wbfy(WillBooster/shared#1176)は開発マシンと self-hosted ランナー(self-host-utils の定期 wbfy 実行経由)を守るが、エフェメラルな GitHub-hosted ランナーには届かない。public リポジトリの release ジョブは publish トークンを持つ最重要ターゲットであり、そこでの新規解決を gate する手段はワークフロー内での適用のみ。
- 「古い package manager の実行は許容しない」という組織方針のため、gate 設定を黙って無視するバージョンは fail-open にせず明示的に CI を落とす(Yarn の home rc は loose mode のため、設定ファイルだけでは壊せないことを実バイナリで確認済み)。

## Testing

- action のスクリプトを抽出し fake $HOME + stub バイナリで実行: github-hosted で 3 ファイル生成(bunfig は `tomllib`、yarnrc は YAML パーサで妥当性・値・除外 24 件を確認)、self-hosted では何も書かないこと、Yarn 3.8.7/4.9.4・Bun 1.2.19 が exit 1、Yarn 1.x/4.10+・Bun 1.3.0+ が exit 0 を確認。
- 実 bun 1.3.14 でグローバル gate が `bunx`/`bun install` の新規解決に効くこと(pin はハードエラー、bare 指定は gate を通る最新版へフォールバック)、lockfile 済み install を壊さないことを確認。
- `bun verify` 通過、編集済み全 YAML のパース確認。multi-agent review(Codex / Claude Code / Antigravity)を収束まで 9 ラウンド実施し、全指摘を修正または反証済み。

## Notes

- 除外リストは wbfy 側の定数が canonical(action 内コメントに明記)。wbfy 側を変更した際はこの action も更新が必要。
- Yarn 1 はいかなる age gate も強制できないが、ワークフローが Yarn 1 リポジトリをサポートし続けているため免除(既知のポリシーギャップ)。
- Takumi Guard の registry 差し替えフローには触れておらず、キー単位マージで共存する(registry はプロジェクト .npmrc、age gate はグローバル)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
