### PR TITLE
chore: remove the vestigial pre-push script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "cleanup": "bun run format",
     "format": "sort-package-json",
-    "pre-push": "echo 'start pre-push'; sleep 60; bun run sync",
     "prepare": "lefthook install || true",
     "sync": "one-way-git-sync -v -i node_modules -i renovate.jsonc -d git@github.com:WillBoosterLab/reusable-workflows.git -b main",
     "sync-force": "bun run sync --force",


### PR DESCRIPTION
## Summary

Removes the `pre-push` script from `package.json`. It is a husky-era leftover: the hook that ran it was never migrated to lefthook (`lefthook.yml` defines no pre-push hook and none is installed), so nothing invokes it. The mirror sync remains the documented manual `bun run sync` per the README.
