### PR TITLE
fix: install with --frozen-lockfile in bun test/release/deploy steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -331,7 +331,13 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
             : # against package.json, so the job would run dependency resolutions that were never
-            : # reviewed or committed (WillBooster/shared#1126).
+            : # reviewed or committed (WillBooster/shared#1126). With NO bun.lock at all,
+            : # --frozen-lockfile silently installs fresh, unpinned resolutions (Bun 1.3.14 exits 0
+            : # and writes no lockfile), so a missing lockfile must fail explicitly.
+            if [[ ! -e bun.lock ]]; then
+              echo "::error::bun.lock is missing; commit it so CI installs stay reproducible"
+              exit 1
+            fi
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
               bun install --frozen-lockfile --ignore-scripts
             else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -329,11 +329,13 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
+            : # against package.json, so the job would run dependency resolutions that were never
+            : # reviewed or committed (WillBooster/shared#1126).
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             else
-              # Because bun sometimes fails to install private repos (but, update is okay)
-              bun install
+              bun install --frozen-lockfile
             fi
           elif [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
             : # No lifecycle scripts run here, so a single retry only covers transient network
@@ -373,13 +375,13 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install || {
+            bun install --frozen-lockfile || {
               : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
               : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
               : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
               echo "::warning::Lifecycle scripts failed; completing the install without them"
               rm -rf node_modules
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,11 +189,13 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
+            : # against package.json, so the job would run dependency resolutions that were never
+            : # reviewed or committed (WillBooster/shared#1126).
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             else
-              # Because bun sometimes fails to install private repos (but, update is okay)
-              bun install
+              bun install --frozen-lockfile
             fi
           elif [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
             : # No lifecycle scripts run here, so a single retry only covers transient network
@@ -233,13 +235,13 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install || {
+            bun install --frozen-lockfile || {
               : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
               : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
               : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
               echo "::warning::Lifecycle scripts failed; completing the install without them"
               rm -rf node_modules
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,13 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
             : # against package.json, so the job would run dependency resolutions that were never
-            : # reviewed or committed (WillBooster/shared#1126).
+            : # reviewed or committed (WillBooster/shared#1126). With NO bun.lock at all,
+            : # --frozen-lockfile silently installs fresh, unpinned resolutions (Bun 1.3.14 exits 0
+            : # and writes no lockfile), so a missing lockfile must fail explicitly.
+            if [[ ! -e bun.lock ]]; then
+              echo "::error::bun.lock is missing; commit it so CI installs stay reproducible"
+              exit 1
+            fi
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
               bun install --frozen-lockfile --ignore-scripts
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,7 +330,13 @@ jobs:
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
             : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
             : # against package.json, so the job would run dependency resolutions that were never
-            : # reviewed or committed (WillBooster/shared#1126).
+            : # reviewed or committed (WillBooster/shared#1126). With NO bun.lock at all,
+            : # --frozen-lockfile silently installs fresh, unpinned resolutions (Bun 1.3.14 exits 0
+            : # and writes no lockfile), so a missing lockfile must fail explicitly.
+            if [[ ! -e bun.lock ]]; then
+              echo "::error::bun.lock is missing; commit it so CI installs stay reproducible"
+              exit 1
+            fi
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
               bun install --frozen-lockfile --ignore-scripts
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,10 +328,13 @@ jobs:
         name: Install dependencies
         run: |
           if [[ "${{ steps.env-info.outputs.runner }}" == "bun" ]]; then
+            : # --frozen-lockfile: a plain `bun install` silently repairs a bun.lock that is stale
+            : # against package.json, so the job would run dependency resolutions that were never
+            : # reviewed or committed (WillBooster/shared#1126).
             if [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             else
-              bun install
+              bun install --frozen-lockfile
             fi
           elif [[ "$HAS_REGISTRY_TOKEN" == "true" ]]; then
             : # No lifecycle scripts run here, so a single retry only covers transient network
@@ -371,13 +374,13 @@ jobs:
             : # A repeated `bun install` is a no-op that does not replay skipped scripts, so
             : # force a full cache-hit re-link.
             rm -rf node_modules
-            bun install || {
+            bun install --frozen-lockfile || {
               : # Keep postinstall failures tolerated (consumers rely on it) while still leaving
               : # a complete node_modules behind — e.g. a repository postinstall that loads fnox
               : # secrets cannot decrypt here because FNOX_AGE_KEY is deliberately step-scoped away.
               echo "::warning::Lifecycle scripts failed; completing the install without them"
               rm -rf node_modules
-              bun install --ignore-scripts
+              bun install --frozen-lockfile --ignore-scripts
             }
           else
             if [[ "${{ steps.env-info.outputs.skip-scripts-option }}" == "--ignore-scripts" ]]; then


### PR DESCRIPTION
Close WillBooster/shared#1126

## Customer Summary

- CI in organization repositories now fails when `bun.lock` is inconsistent with `package.json`, instead of silently "repairing" the lockfile and passing, so release and deploy jobs can no longer run dependency versions that were never reviewed.
- CI also fails with a clear error when `bun.lock` is missing entirely, instead of silently installing unpinned dependency versions.
- Repositories with up-to-date, committed lockfiles (the wbfy-managed norm) are unaffected.

## Technical Summary

- `test.yml`, `release.yml`, `deploy.yml`: every bun install branch now passes `--frozen-lockfile` — the plain (tokenless) install, the Takumi Guard / Verdaccio `--ignore-scripts` install, and the tokenless lifecycle-replay install plus its `--ignore-scripts` fallback (same lockfile as the first install, so freezing there is always consistent).
- The same bun branches abort with `::error::bun.lock is missing` when no lockfile is present, because Bun 1.3.14's `--frozen-lockfile` silently exits 0 without a lockfile, resolving fresh and writing nothing.
- `run-script.yml` is deliberately unchanged: its maintenance scripts (e.g. dependency updates) legitimately regenerate the lockfile. Yarn branches are unchanged (`--no-immutable` there is deliberate).
- The stale comment "Because bun sometimes fails to install private repos" is removed: it originated in 244fd7a for a `bun update --no-save` command and no longer applied.
- The matching change for wbfy's generated self-contained workflows landed in WillBooster/shared#1237.

## Why

- A plain `bun install` silently repairs a stale `bun.lock` (reproduced on Bun 1.3.14), so a PR with an inconsistent lockfile passed CI, and release/deploy jobs could run dependency resolutions absent from the reviewed commit.

## Testing

Verified on actual PRs in WillBooster/shared by pointing its `test.yml` at this branch:

- In-sync `bun.lock` → all checks passed on both the pre-guard commit ([run 31876755693](https://github.com/WillBooster/shared/actions/runs/31876755693)) and the final commit with the guard ([run 31877814482](https://github.com/WillBooster/shared/actions/runs/31877814482)); logs confirm the frozen Takumi Guard install and frozen lifecycle replay ran.
- Deliberately stale `bun.lock` → the install step failed with `error: lockfile had changes, but lockfile is frozen` ([run 31876880946](https://github.com/WillBooster/shared/actions/runs/31876880946)).
- Locally reproduced on Bun 1.3.14: `--frozen-lockfile` fails on a stale lockfile, succeeds silently (writing nothing) with no lockfile, and tolerates version bumps, confirming the guard and the frozen release installs.
