### PR TITLE
chore: remove redundant comments

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,6 @@ pre-commit:
     - name: cleanup
       glob: '**/*.{java}'
       run: |-
-        # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 
 
 
@@ -28,7 +27,6 @@ pre-commit:
       glob: '**/migration.sql'
       run: |-
         failed=0
-        # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
         for file in {staged_files}; do
           if grep -q 'Warnings:' "$file"; then
             echo "Migration SQL file ($file) contains warnings! Please solve the warnings and commit again."


### PR DESCRIPTION
wb / wbfy の機能・仕様は社内で自明である前提に立ち、冗長なコメントを削除しました。

- wb / wbfy / fnox の挙動を説明していたコメント
- コードをそのまま言い換えただけのコメントとセクション区切りコメント
- wbfy が生成物（`lefthook.yml` / `bunfig.toml` / `.gitattributes` / `oxlint.config.ts`）へ書き出していた解説コメント
